### PR TITLE
fix: add Pillow to requirements for CI tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask>=2.0
 gunicorn>=20.0
+Pillow>=10.0.0


### PR DESCRIPTION
The CI test workflow tries to create a PIL image but Pillow wasn't installed. This adds Pillow to requirements.txt.

## Changes
- Added `Pillow>=10.0.0` to requirements.txt

## Testing
- CI tests should now pass