### PR TITLE
fix: use built-in miso-gallery favicon asset

### DIFF
--- a/app.py
+++ b/app.py
@@ -350,6 +350,11 @@ def check_auth():
 def favicon():
     if FAVICON_URL:
         return redirect(FAVICON_URL)
+
+    logo_path = Path(app.root_path) / "assets" / "miso-gallery-logo.png"
+    if logo_path.exists():
+        return send_from_directory(str(logo_path.parent), logo_path.name)
+
     return ("", 204)
 
 


### PR DESCRIPTION
Serve  from  when  is not configured.

This makes favicon app-bundled (same style as miso-chat) and removes need to set favicon URL in home-ops.