### PR TITLE
fix(auth): stop OIDC redirect loop on /auth/oidc

### DIFF
--- a/app.py
+++ b/app.py
@@ -337,7 +337,7 @@ def check_auth():
     if request.path.startswith("/view/") or request.path.startswith("/thumb/") or request.path == "/favicon.ico":
         return None
 
-    if request.path in ["/login", "/auth", "/logout"]:
+    if request.path in ["/login", "/auth", "/logout", "/auth/oidc", "/auth/oidc/callback"]:
         return None
 
     if session.get("authenticated"):


### PR DESCRIPTION
Fixes too-many-redirects when OIDC is enabled by excluding /auth/oidc and /auth/oidc/callback from the global pre-auth redirect guard.