### PR TITLE
fix: move /images route before catch-all for public access

### DIFF
--- a/app.py
+++ b/app.py
@@ -381,6 +381,12 @@ def favicon():
     return ("", 204)
 
 
+@app.route("/images/<path:filename>")
+def images(filename: str):
+    rel_path = sanitize_rel_path(filename)
+    return send_from_directory(str(DATA_FOLDER), rel_path)
+
+
 @app.route("/")
 @app.route("/<path:subpath>")
 @require_auth
@@ -462,12 +468,6 @@ def thumb(filename: str):
             return send_from_directory(str(DATA_FOLDER), rel_path)
 
     return send_from_directory(str(THUMBNAIL_CACHE_DIR), cached_name)
-
-
-@app.route("/images/<path:filename>")
-def images(filename: str):
-    rel_path = sanitize_rel_path(filename)
-    return send_from_directory(str(DATA_FOLDER), rel_path)
 
 
 @app.route("/view/<path:filename>")


### PR DESCRIPTION
The /images/<path> route was defined AFTER the catch-all /<path> route, causing Flask to match catch-all first and redirect to login.

This moves /images/ route before the catch-all so images are served without auth.