### PR TITLE
fix: exclude thumbnail cache entries from /recent

### DIFF
--- a/app.py
+++ b/app.py
@@ -786,13 +786,20 @@ def recent_view():
 
     max_items = 50
     images = []
+    excluded_dirs = {THUMBNAIL_CACHE_DIR.name, ".trash"}
 
     def is_image(path: Path) -> bool:
         return path.suffix.lower() in IMAGE_EXTENSIONS
 
+    def is_excluded_from_recent(path: Path) -> bool:
+        rel_parts = path.relative_to(DATA_FOLDER).parts
+        return any(part in excluded_dirs for part in rel_parts)
+
     try:
         for item in DATA_FOLDER.rglob("*"):
             if not item.is_file() or not is_image(item):
+                continue
+            if is_excluded_from_recent(item):
                 continue
             if item.name.startswith("."):
                 continue


### PR DESCRIPTION
## Summary
Exclude generated thumbnail-cache files from the `/recent` listing so only original gallery images are shown.

## Changes
- add an exclusion set for internal dirs in `recent_view`
- skip files under `.thumb_cache` and `.trash` during recent scan

## Testing
- `python3 -m py_compile app.py security.py auth.py trash.py`

Fixes #54