### PR TITLE
Fix #75: Increase thumbnail max size to 600 for better portrait photos

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ def log_security_event(event: str, outcome: str, **fields: object) -> None:
 
 # Configure OAuth for OIDC if enabled
 configure_oauth(app)
-THUMBNAIL_MAX_SIZE = 400
+THUMBNAIL_MAX_SIZE = 600
 IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".gif", ".webp")
 FAVICON_URL = os.environ.get("FAVICON_URL", "").strip()
 


### PR DESCRIPTION
Closes #75. Increases THUMBNAIL_MAX_SIZE from 400 to 600 to allow portrait photos to show more detail while preserving aspect ratio.