### PR TITLE
fix: persist and clear storage health unhealthy signal

### DIFF
--- a/health.py
+++ b/health.py
@@ -20,6 +20,9 @@ from flask import Blueprint, jsonify
 
 DATA_FOLDER = Path(os.environ.get("DATA_FOLDER", "/data"))
 THUMBNAIL_CACHE_DIR = DATA_FOLDER / ".thumb_cache"
+STORAGE_HEALTH_SIGNAL_FILE = Path(
+    os.environ.get("STORAGE_HEALTH_SIGNAL_FILE", "/tmp/miso-gallery-storage-unhealthy.signal")
+)
 
 health_bp = Blueprint("health", __name__)
 
@@ -62,11 +65,33 @@ def check_storage_write(path: Path) -> tuple[bool, str]:
         return False, f"OS error writing to {path}: {e}"
 
 
+def update_unhealthy_signal(health: dict[str, Any]) -> None:
+    """Persist or clear unhealthy storage signal file."""
+    try:
+        if health["status"] == "unhealthy":
+            STORAGE_HEALTH_SIGNAL_FILE.parent.mkdir(parents=True, exist_ok=True)
+            STORAGE_HEALTH_SIGNAL_FILE.write_text(
+                (
+                    f"status={health['status']}\n"
+                    f"timestamp={health['timestamp']}\n"
+                    f"data_folder={DATA_FOLDER}\n"
+                    f"thumbnail_cache={THUMBNAIL_CACHE_DIR}\n"
+                ),
+                encoding="utf-8",
+            )
+        elif STORAGE_HEALTH_SIGNAL_FILE.exists():
+            STORAGE_HEALTH_SIGNAL_FILE.unlink()
+    except OSError:
+        # Signal file update should not break the health endpoint.
+        pass
+
+
 def get_storage_health() -> dict[str, Any]:
     """Get comprehensive storage health status."""
     health: dict[str, Any] = {
         "status": "healthy",
         "timestamp": datetime.now(timezone.utc).isoformat(),
+        "signal_file": str(STORAGE_HEALTH_SIGNAL_FILE),
         "checks": {
             "data_folder": {"path": str(DATA_FOLDER)},
             "thumbnail_cache": {"path": str(THUMBNAIL_CACHE_DIR)},
@@ -104,7 +129,8 @@ def get_storage_health() -> dict[str, Any]:
     # Determine overall status
     if not (read_ok and write_ok and thumb_read_ok and thumb_write_ok):
         health["status"] = "unhealthy"
-    
+
+    update_unhealthy_signal(health)
     return health
 
 

--- a/tests/test_storage_health.py
+++ b/tests/test_storage_health.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import health
+
+
+def test_unhealthy_creates_signal_file(monkeypatch, tmp_path):
+    data = tmp_path / "data"
+    thumb = data / ".thumb_cache"
+    data.mkdir()
+    thumb.mkdir()
+    signal = tmp_path / "storage-unhealthy.signal"
+
+    monkeypatch.setattr(health, "DATA_FOLDER", data)
+    monkeypatch.setattr(health, "THUMBNAIL_CACHE_DIR", thumb)
+    monkeypatch.setattr(health, "STORAGE_HEALTH_SIGNAL_FILE", signal)
+
+    def fake_read(_path: Path):
+        return True, "Read OK"
+
+    def fake_write(path: Path):
+        if path == thumb:
+            return False, "Write failed"
+        return True, "Write OK"
+
+    monkeypatch.setattr(health, "check_storage_read", fake_read)
+    monkeypatch.setattr(health, "check_storage_write", fake_write)
+
+    result = health.get_storage_health()
+
+    assert result["status"] == "unhealthy"
+    assert signal.exists()
+    text = signal.read_text(encoding="utf-8")
+    assert "unhealthy" in text
+    assert str(data) in text
+
+
+def test_healthy_clears_existing_signal_file(monkeypatch, tmp_path):
+    data = tmp_path / "data"
+    thumb = data / ".thumb_cache"
+    data.mkdir()
+    thumb.mkdir()
+    signal = tmp_path / "storage-unhealthy.signal"
+    signal.write_text("stale unhealthy state", encoding="utf-8")
+
+    monkeypatch.setattr(health, "DATA_FOLDER", data)
+    monkeypatch.setattr(health, "THUMBNAIL_CACHE_DIR", thumb)
+    monkeypatch.setattr(health, "STORAGE_HEALTH_SIGNAL_FILE", signal)
+
+    def always_ok(_path: Path):
+        return True, "OK"
+
+    monkeypatch.setattr(health, "check_storage_read", always_ok)
+    monkeypatch.setattr(health, "check_storage_write", always_ok)
+
+    result = health.get_storage_health()
+
+    assert result["status"] == "healthy"
+    assert not signal.exists()


### PR DESCRIPTION
## Summary
- add persistent unhealthy signal file for storage health failures
- clear stale unhealthy signal automatically when storage recovers
- include signal file path in storage health payload
- add tests for unhealthy signal creation and healthy signal cleanup

## Validation
- pytest -q

Fixes #45