### PR TITLE
fix: add refresh button to /recent page

### DIFF
--- a/app.py
+++ b/app.py
@@ -591,6 +591,7 @@ RECENT_TEMPLATE = """
 <header>
   <h1>🍲 Recent</h1>
   <div class="header-actions">
+    <button type="button" id="refreshRecentBtn" class="refresh-btn" title="Refresh recent images">↻ Refresh</button>
     <button type="button" id="installPwaBtn" class="refresh-btn" hidden>⬇ Install</button>
     <a href="/" class="refresh-btn">← Gallery</a>
   </div>
@@ -616,6 +617,7 @@ RECENT_TEMPLATE = """
 <script>
   let deferredInstallPrompt = null;
   const installBtn = document.getElementById('installPwaBtn');
+  const refreshBtn = document.getElementById('refreshRecentBtn');
 
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
@@ -627,6 +629,10 @@ RECENT_TEMPLATE = """
     event.preventDefault();
     deferredInstallPrompt = event;
     if (installBtn) installBtn.hidden = false;
+  });
+
+  refreshBtn?.addEventListener('click', () => {
+    window.location.reload();
   });
 
   installBtn?.addEventListener('click', async () => {

--- a/tests/test_recent_smoke.py
+++ b/tests/test_recent_smoke.py
@@ -48,6 +48,9 @@ def test_recent_cards_have_valid_view_and_thumb_links(monkeypatch, tmp_path):
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
 
+    assert 'id="refreshRecentBtn"' in html
+    assert "↻ Refresh" in html
+
     # Should include real image from data folder
     assert "cats/cat.png" in html
 


### PR DESCRIPTION
## Summary
Adds a dedicated refresh control to the `/recent` page header so users can manually reload the latest uploads.

## Changes
- Added a `↻ Refresh` button in the `/recent` header action bar
- Wired the button to `window.location.reload()`
- Added a smoke assertion to ensure the refresh button renders in `/recent`

## Testing
- `pytest -q tests/test_recent_smoke.py`

Fixes #82
