### PR TITLE
fix(gallery): skip inaccessible items during NFS /recent scan

### DIFF
--- a/app.py
+++ b/app.py
@@ -1367,34 +1367,38 @@ def recent_view():
 
     try:
         for item in DATA_FOLDER.rglob("*"):
-            if not item.is_file() or not is_image(item):
-                continue
-            if is_excluded_from_recent(item):
-                continue
-            if item.name.startswith("."):
-                continue
             try:
-                mtime = item.stat().st_mtime
-            except OSError:
+                if not item.is_file() or not is_image(item):
+                    continue
+                if is_excluded_from_recent(item):
+                    continue
+                if item.name.startswith("."):
+                    continue
+                try:
+                    mtime = item.stat().st_mtime
+                except OSError:
+                    continue
+
+                rel_path = item.relative_to(DATA_FOLDER).as_posix()
+                date_str = time.strftime("%Y-%m-%d %H:%M", time.localtime(mtime))
+                
+                # Get folder path for navigation
+                folder_path = os.path.dirname(rel_path)
+                folder_url = url_for("index", subpath=folder_path) if folder_path else url_for("index")
+
+                images.append({
+                    "name": item.name,
+                    "rel_path": rel_path,
+                    "url": url_for("view", filename=rel_path),
+                    "thumb": url_for("thumb", filename=rel_path),
+                    "added": date_str,
+                    "size": format_size(item.stat().st_size),
+                    "mtime": mtime,
+                    "folder_url": folder_url,
+                })
+            except (OSError, PermissionError) as e:
+                # Skip items that become inaccessible during NFS attribute cache inconsistency
                 continue
-
-            rel_path = item.relative_to(DATA_FOLDER).as_posix()
-            date_str = time.strftime("%Y-%m-%d %H:%M", time.localtime(mtime))
-            
-            # Get folder path for navigation
-            folder_path = os.path.dirname(rel_path)
-            folder_url = url_for("index", subpath=folder_path) if folder_path else url_for("index")
-
-            images.append({
-                "name": item.name,
-                "rel_path": rel_path,
-                "url": url_for("view", filename=rel_path),
-                "thumb": url_for("thumb", filename=rel_path),
-                "added": date_str,
-                "size": format_size(item.stat().st_size),
-                "mtime": mtime,
-                "folder_url": folder_url,
-            })
     except Exception:
         pass
 


### PR DESCRIPTION
## Classification
PARTIAL FIX

## Summary

Wraps the rglob loop body in recent_view with try/except (OSError, PermissionError) to skip items that become inaccessible during NFS attribute cache traversal instead of crashing the gunicorn sync worker.

When iterating over NFS-mounted directory entries, metadata can become stale — stat() or is_file() calls may hit PermissionError for items that existed when rglob listed the directory. Without the fix, this exception propagated up through gunicorn's sync worker handler, triggering sys.exit(1) and killing the worker.

## Root Cause

The /recent endpoint uses DATA_FOLDER.rglob("*") to recursively scan all files in the NFS-mounted data directory. On NFS, directory entry metadata (uid/gid, permissions) can be stale due to attribute cache inconsistency. When Python later stat()s an iterated item, it may receive PermissionError even though the entry was listed. This exception wasn't caught inside the loop, so it propagated up to gunicorn's worker code which called sys.exit(1).

## Why This Is Partial

This fix prevents worker crashes by skipping inaccessible items, but it doesn't resolve the underlying NFS uid/gid mismatch that causes some entries to be inaccessible. A more complete fix would address the NFS mount configuration or handle the /data/.trash permission issue separately.

## Validation

- python3 -m py_compile app.py
- pytest -q: 21 passed

## Remaining Work

- Investigate and fix NFS mount uid/gid mismatch for .trash and any other root-owned entries
- Consider adding a dedicated pidfile path for gunicorn (e.g., --pid /tmp/gunicorn.pid) to avoid writing to filesystem root
- If NFS scan performance remains a concern, consider caching the recent files list

Refs #113