### PR TITLE
fix: address remaining security findings from #125

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import json
 import os
 import secrets
@@ -31,7 +32,7 @@ from auth import (
     resolved_auth_mode,
     verify_local_password,
 )
-from security import add_security_headers, csrf_token, rate_limit, sanitize_path, validate_csrf
+from security import add_security_headers, csrf_token, is_safe_redirect_url, rate_limit, sanitize_path, validate_csrf
 from trash import empty_trash, list_trash, move_to_trash, purge_old_trash, restore_from_trash
 
 DATA_FOLDER = Path(os.environ.get("DATA_FOLDER", "/data"))
@@ -435,9 +436,9 @@ HTML_TEMPLATE = """
                   <div class="image-details-row"><span class="image-details-label">Modified</span><span class="image-details-value">{{ item.modified }}</span></div>
                 </div>
               </details>
-              <button type="submit" class="delete-btn" formaction="{{ item.delete_url }}" formmethod="POST" onclick="return confirm('Delete {{ item.name }}?')">🗑️</button>
+              <button type="submit" class="delete-btn" formaction="{{ item.delete_url }}" formmethod="POST" onclick="return confirm('Delete ' + {{ item.name | tojson }} + '?')">🗑️</button>
               <a href="{{ item.thumb_url }}" target="_blank" class="thumb-preview-btn" title="View thumbnail only">🖼️ Thumb</a>
-              <button type="button" class="tag-btn" onclick="openTagEditor('{{ item.rel_path }}', '{{ item.name }}')">🏷️ Tag</button>
+              <button type="button" class="tag-btn" onclick="openTagEditor({{ item.rel_path | tojson }}, {{ item.name | tojson }})">🏷️ Tag</button>
             </div>
           {% endif %}
         {% endfor %}
@@ -1160,8 +1161,8 @@ def index(subpath: str = ""):
         crumbs = ['<a href="/">Home</a>']
         for i, part in enumerate(parts[:-1]):
             path = "/".join(parts[: i + 1])
-            crumbs.append(f'<a href="/{path}">{part}</a>')
-        crumbs.append(parts[-1])
+            crumbs.append(f'<a href="/{html.escape(path)}">{html.escape(part)}</a>')
+        crumbs.append(html.escape(parts[-1]))
         breadcrumb = " / ".join(crumbs)
 
         accum: list[str] = []
@@ -1231,7 +1232,7 @@ def thumb(filename: str):
         try:
             generate_thumbnail(source_path, cached_path)
         except (UnidentifiedImageError, OSError):
-            return send_from_directory(str(DATA_FOLDER), rel_path)
+            return "Not found", 404
 
     return send_from_directory(str(THUMBNAIL_CACHE_DIR), cached_name)
 
@@ -1476,7 +1477,8 @@ def trash_purge():
 
 @app.route("/login")
 def login():
-    next_url = request.args.get("next") or "/"
+    raw_next = request.args.get("next") or "/"
+    next_url = raw_next if is_safe_redirect_url(raw_next) else "/"
 
     error_code = (request.args.get("error") or "").strip().lower()
     error_map = {
@@ -1505,7 +1507,8 @@ def auth():
     if not validate_csrf(request.form.get("csrf_token")):
         return {"error": "Invalid CSRF token"}, 403
 
-    next_url = request.form.get("next") or request.args.get("next") or url_for("index")
+    raw_next = request.form.get("next") or request.args.get("next") or "/"
+    next_url = raw_next if is_safe_redirect_url(raw_next) else url_for("index")
 
     if resolved_auth_mode() != "local":
         return redirect(url_for("login", error="local_disabled", next=next_url))
@@ -1562,6 +1565,9 @@ def maintenance_thumbnails_regenerate():
 def webhook_run_task():
     if not _webhook_enabled():
         return {"error": "Webhook tasks are disabled"}, 404
+
+    if not validate_csrf(request.headers.get("X-CSRF-Token")):
+        return {"error": "Invalid CSRF token"}, 403
 
     payload = request.get_json(silent=True) or {}
     task = str(payload.get("task", "")).strip()
@@ -1674,7 +1680,8 @@ def oidc_login():
         return redirect(url_for("login"))
 
     # Store the return URL in session
-    next_url = request.args.get("next") or request.referrer or url_for("index")
+    raw_next = request.args.get("next") or url_for("index")
+    next_url = raw_next if is_safe_redirect_url(raw_next) else url_for("index")
     session["oidc_next_url"] = next_url
 
     # Get the callback URL

--- a/health.py
+++ b/health.py
@@ -31,38 +31,35 @@ def check_storage_read(path: Path) -> tuple[bool, str]:
     """Check if we can read from the storage path."""
     try:
         if not path.exists():
-            return False, f"Path does not exist: {path}"
+            return False, "Path does not exist"
         if not os.access(path, os.R_OK):
-            return False, f"Path is not readable: {path}"
-        # Try to list directory
+            return False, "Path is not readable"
         list(path.iterdir())
         return True, "Read access OK"
-    except PermissionError as e:
-        return False, f"Permission denied reading {path}: {e}"
-    except OSError as e:
-        return False, f"OS error reading {path}: {e}"
+    except PermissionError:
+        return False, "Permission denied reading"
+    except OSError:
+        return False, "OS error reading"
 
 
 def check_storage_write(path: Path) -> tuple[bool, str]:
     """Check if we can write to the storage path (safe test)."""
     try:
         if not path.exists():
-            return False, f"Path does not exist: {path}"
+            return False, "Path does not exist"
         if not os.access(path, os.W_OK):
-            return False, f"Path is not writable: {path}"
-        
-        # Safe write test - create temp file and delete
+            return False, "Path is not writable"
+
         with tempfile.NamedTemporaryFile(dir=path, delete=False) as tmp:
             tmp.write(b"health probe write test")
             tmp_path = tmp.name
-        
-        # Cleanup
+
         os.unlink(tmp_path)
         return True, "Write access OK"
-    except PermissionError as e:
-        return False, f"Permission denied writing to {path}: {e}"
-    except OSError as e:
-        return False, f"OS error writing to {path}: {e}"
+    except PermissionError:
+        return False, "Permission denied writing"
+    except OSError:
+        return False, "OS error writing"
 
 
 def update_unhealthy_signal(health: dict[str, Any]) -> None:
@@ -91,42 +88,36 @@ def get_storage_health() -> dict[str, Any]:
     health: dict[str, Any] = {
         "status": "healthy",
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "signal_file": str(STORAGE_HEALTH_SIGNAL_FILE),
         "checks": {
-            "data_folder": {"path": str(DATA_FOLDER)},
-            "thumbnail_cache": {"path": str(THUMBNAIL_CACHE_DIR)},
+            "data_folder": {},
+            "thumbnail_cache": {},
         },
     }
-    
-    # Check data folder read
+
     read_ok, read_msg = check_storage_read(DATA_FOLDER)
     health["checks"]["data_folder"]["read"] = {
         "ok": read_ok,
         "message": read_msg,
     }
-    
-    # Check data folder write (safe test)
+
     write_ok, write_msg = check_storage_write(DATA_FOLDER)
     health["checks"]["data_folder"]["write"] = {
         "ok": write_ok,
         "message": write_msg,
     }
-    
-    # Check thumbnail cache read
+
     thumb_read_ok, thumb_read_msg = check_storage_read(THUMBNAIL_CACHE_DIR)
     health["checks"]["thumbnail_cache"]["read"] = {
         "ok": thumb_read_ok,
         "message": thumb_read_msg,
     }
-    
-    # Check thumbnail cache write (safe test)
+
     thumb_write_ok, thumb_write_msg = check_storage_write(THUMBNAIL_CACHE_DIR)
     health["checks"]["thumbnail_cache"]["write"] = {
         "ok": thumb_write_ok,
         "message": thumb_write_msg,
     }
-    
-    # Determine overall status
+
     if not (read_ok and write_ok and thumb_read_ok and thumb_write_ok):
         health["status"] = "unhealthy"
 

--- a/security.py
+++ b/security.py
@@ -249,3 +249,12 @@ def csrf_token() -> str:
 def validate_csrf(submitted: str | None) -> bool:
     token = session.get("csrf_token")
     return bool(token and submitted and submitted == token)
+
+
+def is_safe_redirect_url(url: str | None) -> bool:
+    if not url:
+        return True
+    from urllib.parse import urlsplit
+
+    split = urlsplit(url)
+    return split.netloc == "" and split.scheme == "" and not url.startswith("//")


### PR DESCRIPTION
## Summary

Addresses remaining findings from security audit #125:

1. **Open redirect (Medium)** - Added `is_safe_redirect_url()` validator; `next` param is now validated in login, auth, and OIDC flows. Only relative paths starting with `/` are allowed.

2. **XSS (Medium)** - Breadcrumb path parts are now escaped with `html.escape()`. Inline `onclick` handlers use `|tojson` for `item.rel_path` and `item.name`.

3. **Thumbnail DoS (Medium)** - Thumbnail route now returns `404` instead of serving the original file when thumbnail generation fails.

4. **Webhook CSRF (Medium)** - `/api/webhook/run` now requires `X-CSRF-Token` header validation.

5. **Health endpoint disclosure (Low)** - Storage health check messages no longer expose filesystem paths.

## Not addressed (require separate tracking)

- **Dependency audit gaps** - CI/infrastructure concern, not a code fix
- **Session secret file location** - Would be a breaking change; needs careful migration path