### PR TITLE
feat(ci): add pip-audit dependency scanning workflow

### DIFF
--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -1,0 +1,46 @@
+---
+name: Dependency Audit
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 0 * * 0"  # Weekly on Sunday
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@0b0f2145ea8d459c7cc8e2d5c4a1e8d1e9c0a5c # v5.5.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt pip-audit
+
+      - name: Audit requirements.txt
+        run: pip-audit -r requirements.txt --format=spdx --output-file=${{ runner.temp }}/pip-audit-reqs.json
+        continue-on-error: true
+
+      - name: Audit installed environment
+        run: pip-audit --format=spdx --output-file=${{ runner.temp }}/pip-audit-env.json
+        continue-on-error: true
+
+      - name: Upload audit results
+        if: always()
+        uses: actions/upload-artifact@5d5f22ba05c41eb84a4fc2c5e24c2df0e1a0eabe # v4.6.2
+        with:
+          name: pip-audit-results
+          path: ${{ runner.temp }}/pip-audit-*.json
+          retention-days: 30

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: "3.12"
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload audit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5f22ba05c41eb84a4fc2c5e24c2df0e1a0eabe # v4.6.2
         with:
           name: pip-audit-results
           path: ${{ runner.temp }}/pip-audit-*.json

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload audit results
         if: always()
-        uses: actions/upload-artifact@5d5f22ba05c41eb84a4fc2c5e24c2df0e1a0eabe # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pip-audit-results
           path: ${{ runner.temp }}/pip-audit-*.json

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@0b0f2145ea8d459c7cc8e2d5c4a1e8d1e9c0a5c # v5.5.0
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload audit results
         if: always()
-        uses: actions/upload-artifact@5d5f22ba05c41eb84a4fc2c5e24c2df0e1a0eabe # v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: pip-audit-results
           path: ${{ runner.temp }}/pip-audit-*.json


### PR DESCRIPTION
## Summary

Adds a new `dependency-audit` workflow that runs `pip-audit` on every push to main, pull request, and weekly schedule.

- Audits `requirements.txt` directly
- Also audits the full installed environment to catch transitive dependencies
- Uploads results as JSON artifacts for review
- Uses `continue-on-error: true` so the workflow doesn't block merges (vulnerabilities can be addressed separately)

This addresses the "Dependency audit gaps" finding from security audit #125.