### PR TITLE
feat: require SECRET_KEY env var, remove file fallback

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run container
         run: |
-          docker run -d --name gallery -p 5000:5000 -v /tmp/test_images:/data miso-gallery:test
+          docker run -d --name gallery -p 5000:5000 -v /tmp/test_images:/data -e SECRET_KEY=test-secret-key-for-ci miso-gallery:test
           sleep 5
 
       - name: Wait for app and run smoke test

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ docker run -d \
 |----------|----------|---------|-------------|
 | `AUTH_TYPE` | No | `local` | Auth method: `local`, `oidc`, or `none` |
 | `ADMIN_PASSWORD` | If local | - | Password for local auth (plaintext or Werkzeug hash: `pbkdf2:` / `scrypt:`) |
-| `SECRET_KEY` | If OIDC | random | Flask secret for sessions |
+| `SECRET_KEY` | Yes | - | Flask secret for sessions. Generate with: `python -c "import secrets; print(secrets.token_urlsafe(48))"` |
 | `OIDC_ISSUER` | If OIDC | - | OIDC provider URL (e.g., https://authentik.example.com) |
 | `OIDC_CLIENT_ID` | If OIDC | - | OIDC client ID |
 | `OIDC_CLIENT_SECRET` | If OIDC | - | OIDC client secret |

--- a/app.py
+++ b/app.py
@@ -41,28 +41,12 @@ THUMBNAIL_CACHE_DIR = DATA_FOLDER / ".thumb_cache"
 
 def resolve_secret_key() -> str:
     configured = os.environ.get("SECRET_KEY", "").strip()
-    if configured:
-        return configured
-
-    key_file = Path(os.environ.get("SECRET_KEY_FILE", str(DATA_FOLDER / ".miso-gallery-secret-key")))
-
-    try:
-        if key_file.exists():
-            persisted = key_file.read_text(encoding="utf-8").strip()
-            if persisted:
-                return persisted
-    except OSError:
-        pass
-
-    generated = secrets.token_urlsafe(48)
-    try:
-        key_file.parent.mkdir(parents=True, exist_ok=True)
-        key_file.write_text(generated, encoding="utf-8")
-        os.chmod(key_file, 0o600)
-    except OSError:
-        pass
-
-    return generated
+    if not configured:
+        raise ValueError(
+            "SECRET_KEY environment variable is required. "
+            "Generate one with: python -c \"import secrets; print(secrets.token_urlsafe(48))\""
+        )
+    return configured
 
 
 app = Flask(__name__)

--- a/tests/test_auth_matrix.py
+++ b/tests/test_auth_matrix.py
@@ -28,6 +28,7 @@ def build_client(monkeypatch, tmp_path, *, auth_type: str, admin_password: str =
     monkeypatch.setenv("OIDC_ISSUER", "https://issuer.example" if oidc_enabled else "")
     monkeypatch.setenv("OIDC_CLIENT_ID", "client" if oidc_enabled else "")
     monkeypatch.setenv("OIDC_CLIENT_SECRET", "secret" if oidc_enabled else "")
+    monkeypatch.setenv("SECRET_KEY", "test-secret-for-ci")
 
     for mod in ("auth", "app"):
         if mod in sys.modules:


### PR DESCRIPTION
## Summary

`SECRET_KEY` is now a hard requirement. The app raises `ValueError` on startup if it's not set, with instructions on how to generate one.

**Breaking change**: Deployments that relied on the file-based fallback (`DATA_FOLDER/.miso-gallery-secret-key`) will need to be updated to set `SECRET_KEY` explicitly.

This addresses the session secret file location finding from security audit #125. The insecure file-based fallback that could leak through backups/syncs is removed.