### PR TITLE
feat: add LLM-accessible gallery API

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ docker run -d \
 | `AUTH_TYPE` | No | `local` | Auth method: `local`, `oidc`, or `none` |
 | `ADMIN_PASSWORD` | If local | - | Password for local auth (plaintext or Werkzeug hash: `pbkdf2:` / `scrypt:`) |
 | `SECRET_KEY` | Yes | - | Flask secret for sessions. Generate with: `python -c "import secrets; print(secrets.token_urlsafe(48))"` |
+| `LLM_API_KEYS` | No | - | Comma-separated Bearer tokens for the LLM API (`Authorization: Bearer <token>`) |
 | `OIDC_ISSUER` | If OIDC | - | OIDC provider URL (e.g., https://authentik.example.com) |
 | `OIDC_CLIENT_ID` | If OIDC | - | OIDC client ID |
 | `OIDC_CLIENT_SECRET` | If OIDC | - | OIDC client secret |
@@ -182,6 +183,122 @@ Even when authentication is enabled, direct URLs to images remain publicly acces
 - `/thumb/folder/image.jpg` - Thumbnail
 
 This allows sharing images while protecting the gallery UI.
+
+## LLM API
+
+Miso Gallery includes a JSON API intended for LLM agents and other machine-to-machine clients. Enable it by setting one or more comma-separated API keys:
+
+```bash
+docker run -d --name miso-gallery \
+  -p 5000:5000 \
+  -v /path/to/images:/data \
+  -e SECRET_KEY=your-session-secret \
+  -e ADMIN_PASSWORD=your-password \
+  -e LLM_API_KEYS=agent-key-1,agent-key-2 \
+  ghcr.io/joryirving/miso-gallery:latest
+```
+
+Authenticate each request with a Bearer token:
+
+```bash
+curl -H "Authorization: Bearer agent-key-1" \
+  http://localhost:5000/api/llm/images
+```
+
+LLM API endpoints are token-authenticated and do not require CSRF tokens. Existing browser/session authentication continues to work for the UI.
+
+### Read Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/llm/images?q=<query>` | Recursively list/search media. `q` matches filenames or relative paths. |
+| `GET` | `/api/llm/image/<relpath>` | Return metadata for a single image/video. |
+| `GET` | `/api/llm/recent?limit=N` | Return recent media sorted by modification time. Default `50`, max `500`. |
+| `GET` | `/api/llm/folders` | Return folder listing with relative paths and parent folders. |
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer agent-key-1" \
+  "http://localhost:5000/api/llm/images?q=cat"
+```
+
+Response shape:
+
+```json
+{
+  "count": 1,
+  "images": [
+    {
+      "name": "cat.jpg",
+      "rel_path": "cats/cat.jpg",
+      "media_type": "image",
+      "size": 12345,
+      "size_human": "12.1 KB",
+      "modified": "2026-04-28T12:34:56Z",
+      "mtime": 1777398896.0,
+      "view_url": "/view/cats/cat.jpg",
+      "thumb_url": "/thumb/cats/cat.jpg"
+    }
+  ]
+}
+```
+
+### Write Endpoints
+
+| Method | Path | Body | Description |
+|--------|------|------|-------------|
+| `POST` | `/api/llm/tags` | `{"rel_path":"cats/cat.jpg","tag":"favorite","action":"add"}` | Add/remove tags. Tag persistence is currently log-only. |
+| `POST` | `/api/llm/delete` | `{"rel_path":"cats/cat.jpg"}` | Move one media file to trash and clear its thumbnail cache. |
+| `POST` | `/api/llm/bulk-delete` | `{"rel_paths":["a.jpg","b.jpg"]}` | Move multiple media files to trash. |
+| `POST` | `/api/llm/dedup` | `{}` or `{"remove":true}` | Find duplicate media by SHA-256. Defaults to dry-run; `remove:true` moves duplicates to trash. |
+
+Delete example:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer agent-key-1" \
+  -H "Content-Type: application/json" \
+  -d '{"rel_path":"cats/cat.jpg"}' \
+  http://localhost:5000/api/llm/delete
+```
+
+Dedup dry-run example:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer agent-key-1" \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  http://localhost:5000/api/llm/dedup
+```
+
+### Task Execution
+
+The LLM API can run configured webhook tasks without CSRF, using the same task configuration as `/api/webhook/run`.
+
+```bash
+docker run -d --name miso-gallery \
+  -p 5000:5000 \
+  -v /path/to/images:/data \
+  -e SECRET_KEY=your-session-secret \
+  -e LLM_API_KEYS=agent-key-1 \
+  -e WEBHOOK_ENABLED=true \
+  -e 'WEBHOOK_TASK_GENERATE=python3 /data/scripts/generate.py {params.prompt}' \
+  ghcr.io/joryirving/miso-gallery:latest
+```
+
+Run a task:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer agent-key-1" \
+  -H "Content-Type: application/json" \
+  -d '{"task":"generate","params":{"prompt":"a cozy bowl of miso soup"}}' \
+  http://localhost:5000/api/llm/task/run
+```
+
+Task commands run from `DATA_FOLDER`, scalar params are shell-quoted, and the timeout is controlled by `WEBHOOK_TASK_TIMEOUT` with a default of 30 seconds.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ This allows sharing images while protecting the gallery UI.
 
 ## LLM API
 
-Miso Gallery includes a JSON API intended for LLM agents and other machine-to-machine clients. Enable it by setting one or more comma-separated API keys:
+Miso Gallery includes a JSON API intended for LLM agents and other machine-to-machine clients. The primary purpose is to let an external LLM client inspect and manage gallery state: list/search media, read metadata, tag, delete, bulk-delete, and deduplicate images.
+
+Enable the API by setting one or more comma-separated API keys:
 
 ```bash
 docker run -d --name miso-gallery \
@@ -273,9 +275,11 @@ curl -X POST \
   http://localhost:5000/api/llm/dedup
 ```
 
-### Task Execution
+### Optional: Server-Side Task Execution
 
-The LLM API can run configured webhook tasks without CSRF, using the same task configuration as `/api/webhook/run`.
+Most LLM integrations do **not** need task execution. Use the gallery-management endpoints above unless you intentionally want Miso Gallery to expose a small set of preconfigured server-side automation commands.
+
+Task execution is an optional advanced feature that reuses the existing webhook task infrastructure. It is disabled unless `WEBHOOK_ENABLED=true`, and only commands explicitly configured through `WEBHOOK_TASK_*` environment variables can be run. This can be useful for trusted maintenance or generation scripts that should run on the gallery host, but it is not required for normal LLM-to-gallery interaction.
 
 ```bash
 docker run -d --name miso-gallery \
@@ -288,7 +292,7 @@ docker run -d --name miso-gallery \
   ghcr.io/joryirving/miso-gallery:latest
 ```
 
-Run a task:
+Run a configured task:
 
 ```bash
 curl -X POST \

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import html
+import hashlib
 import json
 import os
 import secrets
@@ -28,6 +29,7 @@ from auth import (
     is_auth_enabled,
     is_oidc_configured,
     oauth,
+    require_api_key,
     require_auth,
     resolved_auth_mode,
     verify_local_password,
@@ -987,9 +989,166 @@ def format_size(size: int) -> str:
     return f"{value:.1f} TB"
 
 
+def is_media_file(path: Path) -> bool:
+    return path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS + VIDEO_EXTENSIONS
+
+
+def is_excluded_gallery_path(path: Path) -> bool:
+    try:
+        rel_parts = path.relative_to(DATA_FOLDER).parts
+    except ValueError:
+        return True
+    return any(part in {THUMBNAIL_CACHE_DIR.name, ".trash"} or part.startswith(".") for part in rel_parts)
+
+
+def media_metadata(path: Path) -> dict[str, object]:
+    rel_path = path.relative_to(DATA_FOLDER).as_posix()
+    stat = path.stat()
+    media_type = "video" if path.suffix.lower() in VIDEO_EXTENSIONS else "image"
+    return {
+        "name": path.name,
+        "rel_path": rel_path,
+        "media_type": media_type,
+        "size": stat.st_size,
+        "size_human": format_size(stat.st_size),
+        "modified": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(stat.st_mtime)),
+        "mtime": stat.st_mtime,
+        "view_url": url_for("view", filename=rel_path),
+        "thumb_url": url_for("thumb", filename=rel_path),
+    }
+
+
+def iter_gallery_media() -> list[Path]:
+    media: list[Path] = []
+    for item in DATA_FOLDER.rglob("*"):
+        try:
+            if is_media_file(item) and not is_excluded_gallery_path(item):
+                media.append(item)
+        except (OSError, PermissionError):
+            continue
+    return sorted(media, key=lambda p: p.relative_to(DATA_FOLDER).as_posix().lower())
+
+
+def iter_gallery_folders() -> list[Path]:
+    folders: list[Path] = []
+    for item in DATA_FOLDER.rglob("*"):
+        try:
+            if item.is_dir() and not is_excluded_gallery_path(item):
+                folders.append(item)
+        except (OSError, PermissionError):
+            continue
+    return sorted(folders, key=lambda p: p.relative_to(DATA_FOLDER).as_posix().lower())
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def find_duplicate_media() -> list[dict[str, object]]:
+    by_size: dict[int, list[Path]] = {}
+    for item in iter_gallery_media():
+        try:
+            by_size.setdefault(item.stat().st_size, []).append(item)
+        except OSError:
+            continue
+
+    groups: list[dict[str, object]] = []
+    for same_size in by_size.values():
+        if len(same_size) < 2:
+            continue
+        by_hash: dict[str, list[Path]] = {}
+        for item in same_size:
+            try:
+                by_hash.setdefault(file_sha256(item), []).append(item)
+            except OSError:
+                continue
+        for digest, matches in by_hash.items():
+            if len(matches) < 2:
+                continue
+            matches = sorted(matches, key=lambda p: p.relative_to(DATA_FOLDER).as_posix().lower())
+            groups.append(
+                {
+                    "hash": digest,
+                    "size": matches[0].stat().st_size,
+                    "keep": matches[0].relative_to(DATA_FOLDER).as_posix(),
+                    "duplicates": [p.relative_to(DATA_FOLDER).as_posix() for p in matches[1:]],
+                    "all": [p.relative_to(DATA_FOLDER).as_posix() for p in matches],
+                }
+            )
+    return groups
+
+
+def run_configured_task(payload: dict[str, object]) -> tuple[dict[str, object], int]:
+    if not _webhook_enabled():
+        return {"error": "Webhook tasks are disabled"}, 404
+
+    task = str(payload.get("task", "")).strip()
+    params = payload.get("params") or {}
+
+    if not task:
+        return {"error": "task is required"}, 400
+    if not isinstance(params, dict):
+        return {"error": "params must be an object"}, 400
+
+    env_key = _task_env_key(task)
+    if not env_key:
+        return {"error": "invalid task name"}, 400
+
+    template = os.environ.get(env_key, "").strip()
+    if not template:
+        return {"error": f"task '{task}' is not configured"}, 404
+
+    try:
+        command = _render_task_command(template, params)
+        argv = shlex.split(command)
+    except ValueError as exc:
+        return {"error": str(exc)}, 400
+
+    if not argv:
+        return {"error": "configured task produced an empty command"}, 500
+
+    try:
+        timeout = max(1, min(600, int(os.environ.get("WEBHOOK_TASK_TIMEOUT", "30"))))
+    except ValueError:
+        timeout = 30
+
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=str(DATA_FOLDER),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        log_security_event("webhook_task", "error", task=task, reason="timeout", timeout=timeout)
+        return {"task": task, "success": False, "error": f"task timed out after {timeout}s"}, 504
+    except OSError as exc:
+        log_security_event("webhook_task", "error", task=task, reason="spawn_failed", error=str(exc))
+        return {"task": task, "success": False, "error": f"failed to execute task: {exc}"}, 500
+
+    success = completed.returncode == 0
+    log_security_event("webhook_task", "success" if success else "error", task=task, exit_code=completed.returncode)
+    return {
+        "task": task,
+        "success": success,
+        "exitCode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+    }, 200
+
+
 @app.before_request
 def check_auth():
     if not is_auth_enabled():
+        return None
+
+    if request.path.startswith("/api/llm/"):
         return None
 
     if request.path.startswith("/images/") or request.path.startswith("/view/"):
@@ -1547,74 +1706,158 @@ def maintenance_thumbnails_regenerate():
 @require_auth
 @rate_limit(max_requests=20, window=60)
 def webhook_run_task():
-    if not _webhook_enabled():
-        return {"error": "Webhook tasks are disabled"}, 404
-
-    if not validate_csrf(request.headers.get("X-CSRF-Token")):
+    if is_auth_enabled() and not validate_csrf(request.headers.get("X-CSRF-Token")):
         return {"error": "Invalid CSRF token"}, 403
 
-    payload = request.get_json(silent=True) or {}
-    task = str(payload.get("task", "")).strip()
-    params = payload.get("params") or {}
+    body, status = run_configured_task(request.get_json(silent=True) or {})
+    return body, status
 
-    if not task:
-        return {"error": "task is required"}, 400
-    if not isinstance(params, dict):
-        return {"error": "params must be an object"}, 400
 
-    env_key = _task_env_key(task)
-    if not env_key:
-        return {"error": "invalid task name"}, 400
+@app.route("/api/llm/images")
+@require_api_key
+@rate_limit(max_requests=60, window=60)
+def llm_images():
+    query = request.args.get("q", "").strip().lower()
+    images = []
+    for item in iter_gallery_media():
+        rel_path = item.relative_to(DATA_FOLDER).as_posix()
+        if query and query not in rel_path.lower() and query not in item.name.lower():
+            continue
+        images.append(media_metadata(item))
+    return {"images": images, "count": len(images)}
 
-    template = os.environ.get(env_key, "").strip()
-    if not template:
-        return {"error": f"task '{task}' is not configured"}, 404
 
+@app.route("/api/llm/image/<path:relpath>")
+@require_api_key
+@rate_limit(max_requests=60, window=60)
+def llm_image(relpath: str):
+    if not sanitize_path(relpath):
+        return {"error": "Invalid path"}, 400
+    media_path = source_file_path(relpath)
+    if not media_path.exists() or not is_media_file(media_path) or is_excluded_gallery_path(media_path):
+        return {"error": "Image not found"}, 404
+    return media_metadata(media_path)
+
+
+@app.route("/api/llm/recent")
+@require_api_key
+@rate_limit(max_requests=60, window=60)
+def llm_recent():
     try:
-        command = _render_task_command(template, params)
-        argv = shlex.split(command)
-    except ValueError as exc:
-        return {"error": str(exc)}, 400
-
-    if not argv:
-        return {"error": "configured task produced an empty command"}, 500
-
-    try:
-        timeout = max(1, min(600, int(os.environ.get("WEBHOOK_TASK_TIMEOUT", "30"))))
+        limit = max(1, min(500, int(request.args.get("limit", "50"))))
     except ValueError:
-        timeout = 30
+        limit = 50
+    media = sorted(iter_gallery_media(), key=lambda p: p.stat().st_mtime, reverse=True)[:limit]
+    return {"images": [media_metadata(item) for item in media], "count": len(media)}
 
-    try:
-        completed = subprocess.run(
-            argv,
-            cwd=str(DATA_FOLDER),
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
-        )
-    except subprocess.TimeoutExpired:
-        log_security_event("webhook_task", "error", task=task, reason="timeout", timeout=timeout)
-        return {"task": task, "success": False, "error": f"task timed out after {timeout}s"}, 504
-    except OSError as exc:
-        log_security_event("webhook_task", "error", task=task, reason="spawn_failed", error=str(exc))
-        return {"task": task, "success": False, "error": f"failed to execute task: {exc}"}, 500
 
-    success = completed.returncode == 0
-    log_security_event(
-        "webhook_task",
-        "success" if success else "error",
-        task=task,
-        exit_code=completed.returncode,
-    )
+@app.route("/api/llm/folders")
+@require_api_key
+@rate_limit(max_requests=60, window=60)
+def llm_folders():
+    folders = [{"rel_path": "", "name": "", "parent": None}]
+    for folder in iter_gallery_folders():
+        rel_path = folder.relative_to(DATA_FOLDER).as_posix()
+        parent = folder.parent.relative_to(DATA_FOLDER).as_posix() if folder.parent != DATA_FOLDER else ""
+        folders.append({"rel_path": rel_path, "name": folder.name, "parent": parent})
+    return {"folders": folders, "count": len(folders)}
 
-    return {
-        "task": task,
-        "success": success,
-        "exitCode": completed.returncode,
-        "stdout": completed.stdout,
-        "stderr": completed.stderr,
-    }
+
+@app.route("/api/llm/tags", methods=["POST"])
+@require_api_key
+@rate_limit(max_requests=30, window=60)
+def llm_tags():
+    payload = request.get_json(silent=True) or {}
+    rel_paths = payload.get("rel_paths") or payload.get("images") or payload.get("rel_path")
+    tags = payload.get("tags") or payload.get("tag")
+    action = str(payload.get("action", "add")).strip().lower()
+    if isinstance(rel_paths, str):
+        rel_paths = [rel_paths]
+    if isinstance(tags, str):
+        tags = [tags]
+    if not isinstance(rel_paths, list) or not isinstance(tags, list) or action not in {"add", "remove"}:
+        return {"error": "rel_paths/images, tags, and action=add|remove are required"}, 400
+    updated = []
+    for rel_path in rel_paths:
+        if not isinstance(rel_path, str) or not sanitize_path(rel_path):
+            continue
+        safe_rel_path = sanitize_rel_path(rel_path)
+        media_path = source_file_path(safe_rel_path)
+        if media_path.exists() and is_media_file(media_path) and not is_excluded_gallery_path(media_path):
+            updated.append(safe_rel_path)
+    log_security_event("llm_tags", "success", action=action, updated=len(updated), tags=[str(tag) for tag in tags])
+    return {"status": "ok", "action": action, "updated": updated, "tags": [str(tag) for tag in tags]}
+
+
+@app.route("/api/llm/delete", methods=["POST"])
+@require_api_key
+@rate_limit(max_requests=20, window=60)
+def llm_delete():
+    payload = request.get_json(silent=True) or {}
+    rel_path = str(payload.get("rel_path") or payload.get("image") or "")
+    if not rel_path or not sanitize_path(rel_path):
+        return {"error": "Valid rel_path is required"}, 400
+    safe_rel_path = sanitize_rel_path(rel_path)
+    media_path = source_file_path(safe_rel_path)
+    if not media_path.exists() or not is_media_file(media_path) or is_excluded_gallery_path(media_path):
+        return {"error": "Image not found"}, 404
+    moved = move_to_trash(media_path, DATA_FOLDER)
+    if moved:
+        remove_thumbnail_cache_for(safe_rel_path)
+    log_security_event("llm_delete", "success" if moved else "error", target=safe_rel_path)
+    return {"deleted": moved, "rel_path": safe_rel_path}, 200 if moved else 500
+
+
+@app.route("/api/llm/bulk-delete", methods=["POST"])
+@require_api_key
+@rate_limit(max_requests=10, window=60)
+def llm_bulk_delete():
+    payload = request.get_json(silent=True) or {}
+    rel_paths = payload.get("rel_paths") or payload.get("images") or []
+    if not isinstance(rel_paths, list):
+        return {"error": "rel_paths/images must be a list"}, 400
+    deleted = []
+    skipped = []
+    for rel_path in rel_paths:
+        if not isinstance(rel_path, str) or not sanitize_path(rel_path):
+            skipped.append(str(rel_path))
+            continue
+        safe_rel_path = sanitize_rel_path(rel_path)
+        media_path = source_file_path(safe_rel_path)
+        if media_path.exists() and is_media_file(media_path) and not is_excluded_gallery_path(media_path) and move_to_trash(media_path, DATA_FOLDER):
+            remove_thumbnail_cache_for(safe_rel_path)
+            deleted.append(safe_rel_path)
+        else:
+            skipped.append(safe_rel_path)
+    log_security_event("llm_bulk_delete", "success" if deleted else "noop", deleted=len(deleted), skipped=len(skipped))
+    return {"deleted": deleted, "skipped": skipped, "deleted_count": len(deleted), "skipped_count": len(skipped)}
+
+
+@app.route("/api/llm/dedup", methods=["POST"])
+@require_api_key
+@rate_limit(max_requests=5, window=60)
+def llm_dedup():
+    payload = request.get_json(silent=True) or {}
+    remove = bool(payload.get("remove") or payload.get("delete"))
+    groups = find_duplicate_media()
+    removed = []
+    if remove:
+        for group in groups:
+            for rel_path in group["duplicates"]:
+                media_path = source_file_path(str(rel_path))
+                if media_path.exists() and move_to_trash(media_path, DATA_FOLDER):
+                    remove_thumbnail_cache_for(str(rel_path))
+                    removed.append(str(rel_path))
+    log_security_event("llm_dedup", "success", groups=len(groups), removed=len(removed), dry_run=not remove)
+    return {"duplicate_groups": groups, "group_count": len(groups), "dry_run": not remove, "removed": removed}
+
+
+@app.route("/api/llm/task/run", methods=["POST"])
+@require_api_key
+@rate_limit(max_requests=10, window=60)
+def llm_task_run():
+    body, status = run_configured_task(request.get_json(silent=True) or {})
+    return body, status
 
 
 @app.route("/settings")

--- a/auth.py
+++ b/auth.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import os
+import secrets
 from functools import wraps
 from typing import Literal
 
-from flask import redirect, request, session, url_for
+from flask import jsonify, redirect, request, session, url_for
 from werkzeug.security import check_password_hash
 from authlib.integrations.flask_client import OAuth
 
@@ -14,6 +15,7 @@ AuthMode = Literal["none", "local", "oidc"]
 
 AUTH_TYPE = os.environ.get("AUTH_TYPE", "local").strip().lower()
 ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD", "").strip()
+LLM_API_KEYS = [key.strip() for key in os.environ.get("LLM_API_KEYS", "").split(",") if key.strip()]
 
 # OIDC Configuration
 OIDC_ENABLED = os.environ.get("OIDC_ENABLED", "").strip().lower() == "true"
@@ -74,6 +76,24 @@ def is_authenticated() -> bool:
     return bool(session.get("authenticated"))
 
 
+def is_api_key_auth_enabled() -> bool:
+    return bool(LLM_API_KEYS)
+
+
+def _bearer_token() -> str:
+    auth_header = request.headers.get("Authorization", "")
+    scheme, _, token = auth_header.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        return ""
+    return token.strip()
+
+
+def verify_api_key(token: str) -> bool:
+    if not token or not LLM_API_KEYS:
+        return False
+    return any(secrets.compare_digest(token, configured) for configured in LLM_API_KEYS)
+
+
 def verify_local_password(password: str) -> bool:
     """Verify local password.
 
@@ -98,6 +118,20 @@ def require_auth(view_fn):
         if is_authenticated():
             return view_fn(*args, **kwargs)
         return redirect(url_for("login", next=request.path))
+
+    return wrapper
+
+
+def require_api_key(view_fn):
+    @wraps(view_fn)
+    def wrapper(*args, **kwargs):
+        if verify_api_key(_bearer_token()):
+            return view_fn(*args, **kwargs)
+        if is_authenticated():
+            return view_fn(*args, **kwargs)
+        if not is_api_key_auth_enabled():
+            return jsonify({"error": "LLM API keys are not configured"}), 403
+        return jsonify({"error": "Bearer token required"}), 401
 
     return wrapper
 

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -1,0 +1,136 @@
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _build_client(monkeypatch, tmp_path, *, api_keys="agent-key", auth_type="local"):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "sample.png").write_bytes(b"image-one")
+    (data_dir / "copy.png").write_bytes(b"image-one")
+    nested = data_dir / "cats"
+    nested.mkdir()
+    (nested / "cat.jpg").write_bytes(b"cat")
+    (data_dir / ".thumb_cache").mkdir()
+    (data_dir / ".thumb_cache" / "hidden.png").write_bytes(b"hidden")
+
+    monkeypatch.setenv("DATA_FOLDER", str(data_dir))
+    monkeypatch.setenv("AUTH_TYPE", auth_type)
+    monkeypatch.setenv("ADMIN_PASSWORD", "pass123" if auth_type == "local" else "")
+    monkeypatch.setenv("OIDC_ENABLED", "false")
+    monkeypatch.setenv("SECRET_KEY", "test-secret-for-ci")
+    if api_keys is None:
+        monkeypatch.delenv("LLM_API_KEYS", raising=False)
+    else:
+        monkeypatch.setenv("LLM_API_KEYS", api_keys)
+
+    for mod in ("auth", "app"):
+        if mod in sys.modules:
+            del sys.modules[mod]
+
+    app_module = importlib.import_module("app")
+    app_module.DATA_FOLDER = data_dir
+    app_module.THUMBNAIL_CACHE_DIR = data_dir / ".thumb_cache"
+    app_module.app.config["TESTING"] = True
+    return app_module.app.test_client(), data_dir
+
+
+def _auth(token="agent-key"):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_llm_api_requires_configured_valid_bearer_token(monkeypatch, tmp_path):
+    client, _ = _build_client(monkeypatch, tmp_path)
+
+    assert client.get("/api/llm/images").status_code == 401
+    assert client.get("/api/llm/images", headers=_auth("wrong")).status_code == 401
+    assert client.get("/api/llm/images", headers=_auth()).status_code == 200
+
+
+def test_llm_api_reports_unconfigured_keys(monkeypatch, tmp_path):
+    client, _ = _build_client(monkeypatch, tmp_path, api_keys=None, auth_type="none")
+
+    resp = client.get("/api/llm/images")
+
+    assert resp.status_code == 403
+    assert resp.get_json()["error"] == "LLM API keys are not configured"
+
+
+def test_llm_images_search_metadata_recent_and_folders(monkeypatch, tmp_path):
+    client, _ = _build_client(monkeypatch, tmp_path)
+
+    images = client.get("/api/llm/images?q=cat", headers=_auth())
+    assert images.status_code == 200
+    payload = images.get_json()
+    assert payload["count"] == 1
+    assert payload["images"][0]["rel_path"] == "cats/cat.jpg"
+
+    image = client.get("/api/llm/image/cats/cat.jpg", headers=_auth())
+    assert image.status_code == 200
+    assert image.get_json()["media_type"] == "image"
+
+    recent = client.get("/api/llm/recent?limit=2", headers=_auth())
+    assert recent.status_code == 200
+    assert recent.get_json()["count"] == 2
+
+    folders = client.get("/api/llm/folders", headers=_auth())
+    assert folders.status_code == 200
+    assert any(folder["rel_path"] == "cats" for folder in folders.get_json()["folders"])
+
+
+def test_llm_delete_and_bulk_delete_do_not_require_csrf(monkeypatch, tmp_path):
+    client, data_dir = _build_client(monkeypatch, tmp_path)
+
+    delete = client.post("/api/llm/delete", json={"rel_path": "cats/cat.jpg"}, headers=_auth())
+    assert delete.status_code == 200
+    assert delete.get_json()["deleted"] is True
+    assert not (data_dir / "cats" / "cat.jpg").exists()
+
+    bulk = client.post("/api/llm/bulk-delete", json={"rel_paths": ["sample.png"]}, headers=_auth())
+    assert bulk.status_code == 200
+    assert bulk.get_json()["deleted"] == ["sample.png"]
+    assert not (data_dir / "sample.png").exists()
+
+
+def test_llm_dedup_dry_run_and_remove(monkeypatch, tmp_path):
+    client, data_dir = _build_client(monkeypatch, tmp_path)
+
+    dry_run = client.post("/api/llm/dedup", json={}, headers=_auth())
+    assert dry_run.status_code == 200
+    dry_payload = dry_run.get_json()
+    assert dry_payload["dry_run"] is True
+    assert dry_payload["group_count"] == 1
+    assert dry_payload["removed"] == []
+
+    remove = client.post("/api/llm/dedup", json={"remove": True}, headers=_auth())
+    assert remove.status_code == 200
+    payload = remove.get_json()
+    assert payload["dry_run"] is False
+    assert payload["removed"] == ["sample.png"]
+    assert not (data_dir / "sample.png").exists()
+
+
+def test_llm_tags_and_task_run(monkeypatch, tmp_path):
+    monkeypatch.setenv("WEBHOOK_ENABLED", "true")
+    monkeypatch.setenv("WEBHOOK_TASK_ECHO", "python3 -c \"import sys;print(sys.argv[1])\" {params.value}")
+    client, _ = _build_client(monkeypatch, tmp_path)
+
+    tags = client.post(
+        "/api/llm/tags",
+        json={"rel_path": "sample.png", "tag": "miso", "action": "add"},
+        headers=_auth(),
+    )
+    assert tags.status_code == 200
+    assert tags.get_json()["updated"] == ["sample.png"]
+
+    task = client.post(
+        "/api/llm/task/run",
+        json={"task": "echo", "params": {"value": "hello"}},
+        headers=_auth(),
+    )
+    assert task.status_code == 200
+    assert task.get_json()["stdout"].strip() == "hello"


### PR DESCRIPTION
## Summary
- Add Bearer token auth via LLM_API_KEYS for machine-to-machine gallery access
- Add /api/llm endpoints for listing/searching media, metadata, recent media, folders, tags, delete/bulk-delete, dedup, and task execution
- Reuse existing trash, thumbnail cleanup, rate limiting, and webhook task execution paths
- Add tests for LLM API auth and operations

Closes #132

## Validation
- SECRET_KEY=test-secret-for-ci /tmp/miso-gallery-venv/bin/python -m pytest tests
- git diff --check