### PR TITLE
Add shared conftest.py for test SECRET_KEY bootstrap

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+"""Shared pytest fixtures for miso-gallery tests.
+
+Ensures required environment variables are set before any test module
+imports the app (which requires SECRET_KEY at import time).
+"""
+
+import os
+
+# Set a deterministic SECRET_KEY so app.py can import successfully
+# without requiring it to be pre-set in the environment.
+os.environ.setdefault("SECRET_KEY", "test-secret-for-ci")


### PR DESCRIPTION
Fixes audit #142: test suite was failing without SECRET_KEY set globally because app.py requires it at import time. Several test helpers didn't set it before importing the app, causing false failures when running pytest directly (only CI Docker smoke path masked this).

The conftest.py sets a deterministic test SECRET_KEY at module level, ensuring it's available before any test module imports the app. This eliminates copy-pasted SECRET_KEY setup across multiple test files and fixes the hidden environment coupling.

Refs #139, #142