### PR TITLE
chore: bump APP_VERSION from 0.1.14 to 0.1.16

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,7 +107,7 @@ FAVICON_URL = os.environ.get("FAVICON_URL", "").strip()
 
 PWA_THEME_COLOR = "#0d0d0d"
 PWA_APP_NAME = "Miso Gallery"
-APP_VERSION = (os.environ.get("APP_VERSION") or "0.1.14").strip() or "0.1.14"
+APP_VERSION = (os.environ.get("APP_VERSION") or "0.1.16").strip() or "0.1.16"
 WEBHOOK_TASK_PREFIX = "WEBHOOK_TASK_"
 AUTO_FOLDER_COVERS_ENABLED = os.environ.get("GALLERY_AUTO_FOLDER_COVERS", "false").strip().lower() in {"1", "true", "yes", "on"}
 FOLDER_COVER_CACHE_TTL = max(int(os.environ.get("GALLERY_COVER_CACHE_TTL", "3600") or 3600), 0)


### PR DESCRIPTION
Refs #139. Addresses one finding from the weekly audit: version drift.

## Change

Bumped `APP_VERSION` default in `app.py` from `0.1.14` to `0.1.16` to match the latest GitHub release tag (published 2026-04-29).

## Context

The audit found that `/about` and UI version display were misleading operators because the in-app version constant was two minor versions behind the actual release. The manual release workflow exists but had a recent failure, so the invariant wasn't preserved automatically.

## Scope

This is the immediate fix (version bump). More durable solutions—CI checks validating `APP_VERSION` consistency during release, or deriving version from build metadata—are tracked as follow-up issues and can be addressed in separate PRs.