### PR TITLE
[#142] Add shared pytest fixture for SECRET_KEY and test bootstrap

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,88 @@
+"""Shared pytest bootstrap for miso-gallery tests.
+
+Provides:
+- TEST_SECRET: constant for SECRET_KEY env var used in all tests
+- TEST_API_KEY: default API key for LLM endpoint tests
+- build_client(): builds a Flask test client with isolated DATA_FOLDER and module state
+- auth_header(): returns a valid Authorization header dict
+
+Usage in test files::
+
+    from conftest import build_client, auth_header
+
+    def test_something(monkeypatch, tmp_path):
+        client, data_dir = build_client(monkeypatch, tmp_path)
+        ...
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+TEST_SECRET = "test-secret-for-ci"
+TEST_API_KEY = "agent-key"
+
+
+def build_client(monkeypatch, tmp_path, *, api_keys: str = TEST_API_KEY, auth_type: str = "local"):
+    """Build a Flask test client with test env vars and isolated module state.
+
+    Creates the same image fixture data as the original _build_client helper:
+    - sample.png / copy.png (identical bytes, used for dedup tests)
+    - cats/cat.jpg
+    - .thumb_cache/hidden.png
+
+    Env vars set before app import:
+    - DATA_FOLDER      → tmp_path / "data"
+    - AUTH_TYPE        → auth_type param
+    - ADMIN_PASSWORD   → "pass123" (unless auth_type != "local")
+    - OIDC_ENABLED     → "false"
+    - SECRET_KEY       → TEST_SECRET
+    - LLM_API_KEYS     → api_keys param (pass None to leave unset)
+
+    Returns (client, data_dir).
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / ".thumb_cache").mkdir(exist_ok=True)
+    (data_dir / ".thumb_cache" / "hidden.png").write_bytes(b"hidden-cache")
+
+    # Duplicate-content pair used by dedup tests
+    (data_dir / "sample.png").write_bytes(b"image-one")
+    (data_dir / "copy.png").write_bytes(b"image-one")
+
+    # cats subdir for search/LLM tests
+    nested = data_dir / "cats"
+    nested.mkdir()
+    (nested / "cat.jpg").write_bytes(b"cat")
+
+    monkeypatch.setenv("DATA_FOLDER", str(data_dir))
+    monkeypatch.setenv("AUTH_TYPE", auth_type)
+    monkeypatch.setenv("ADMIN_PASSWORD", "pass123" if auth_type == "local" else "")
+    monkeypatch.setenv("OIDC_ENABLED", "false")
+    monkeypatch.setenv("SECRET_KEY", TEST_SECRET)
+
+    if api_keys is None:
+        monkeypatch.delenv("LLM_API_KEYS", raising=False)
+    else:
+        monkeypatch.setenv("LLM_API_KEYS", api_keys)
+
+    for mod in ("auth", "app"):
+        sys.modules.pop(mod, None)
+
+    app_module = importlib.import_module("app")
+    app_module.DATA_FOLDER = data_dir
+    app_module.THUMBNAIL_CACHE_DIR = data_dir / ".thumb_cache"
+    app_module.app.config["TESTING"] = True
+
+    return app_module.app.test_client(), data_dir
+
+
+def auth_header(token: str = TEST_API_KEY) -> dict:
+    """Return a dict suitable for Authorization: Bearer <token> headers."""
+    return {"Authorization": f"Bearer {token}"}

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -27,9 +27,13 @@ def test_llm_images_search_metadata_recent_and_folders(monkeypatch, tmp_path):
     assert payload["count"] == 1
     assert payload["images"][0]["rel_path"] == "cats/cat.jpg"
 
-    recent = client.get("/api/llm/recent", headers=auth_header())
+    image = client.get("/api/llm/image/cats/cat.jpg", headers=auth_header())
+    assert image.status_code == 200
+    assert image.get_json()["media_type"] == "image"
+
+    recent = client.get("/api/llm/recent?limit=2", headers=auth_header())
     assert recent.status_code == 200
-    assert recent.get_json()["count"] >= 1
+    assert recent.get_json()["count"] == 2
 
     folders = client.get("/api/llm/folders", headers=auth_header())
     assert folders.status_code == 200
@@ -66,3 +70,25 @@ def test_llm_dedup_dry_run_and_remove(monkeypatch, tmp_path):
     assert payload["dry_run"] is False
     assert payload["removed"] == ["sample.png"]
     assert not (data_dir / "sample.png").exists()
+
+
+def test_llm_tags_and_task_run(monkeypatch, tmp_path):
+    monkeypatch.setenv("WEBHOOK_ENABLED", "true")
+    monkeypatch.setenv("WEBHOOK_TASK_ECHO", "python3 -c \"import sys;print(sys.argv[1])\" {params.value}")
+    client, _ = build_client(monkeypatch, tmp_path)
+
+    tags = client.post(
+        "/api/llm/tags",
+        json={"rel_path": "sample.png", "tag": "miso", "action": "add"},
+        headers=auth_header(),
+    )
+    assert tags.status_code == 200
+    assert tags.get_json()["updated"] == ["sample.png"]
+
+    task = client.post(
+        "/api/llm/task/run",
+        json={"task": "echo", "params": {"value": "hello"}},
+        headers=auth_header(),
+    )
+    assert task.status_code == 200
+    assert task.get_json()["stdout"].strip() == "hello"

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -1,58 +1,16 @@
-import importlib
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-
-def _build_client(monkeypatch, tmp_path, *, api_keys="agent-key", auth_type="local"):
-    data_dir = tmp_path / "data"
-    data_dir.mkdir(parents=True, exist_ok=True)
-    (data_dir / "sample.png").write_bytes(b"image-one")
-    (data_dir / "copy.png").write_bytes(b"image-one")
-    nested = data_dir / "cats"
-    nested.mkdir()
-    (nested / "cat.jpg").write_bytes(b"cat")
-    (data_dir / ".thumb_cache").mkdir()
-    (data_dir / ".thumb_cache" / "hidden.png").write_bytes(b"hidden")
-
-    monkeypatch.setenv("DATA_FOLDER", str(data_dir))
-    monkeypatch.setenv("AUTH_TYPE", auth_type)
-    monkeypatch.setenv("ADMIN_PASSWORD", "pass123" if auth_type == "local" else "")
-    monkeypatch.setenv("OIDC_ENABLED", "false")
-    monkeypatch.setenv("SECRET_KEY", "test-secret-for-ci")
-    if api_keys is None:
-        monkeypatch.delenv("LLM_API_KEYS", raising=False)
-    else:
-        monkeypatch.setenv("LLM_API_KEYS", api_keys)
-
-    for mod in ("auth", "app"):
-        if mod in sys.modules:
-            del sys.modules[mod]
-
-    app_module = importlib.import_module("app")
-    app_module.DATA_FOLDER = data_dir
-    app_module.THUMBNAIL_CACHE_DIR = data_dir / ".thumb_cache"
-    app_module.app.config["TESTING"] = True
-    return app_module.app.test_client(), data_dir
-
-
-def _auth(token="agent-key"):
-    return {"Authorization": f"Bearer {token}"}
+from conftest import build_client, auth_header
 
 
 def test_llm_api_requires_configured_valid_bearer_token(monkeypatch, tmp_path):
-    client, _ = _build_client(monkeypatch, tmp_path)
+    client, _ = build_client(monkeypatch, tmp_path)
 
     assert client.get("/api/llm/images").status_code == 401
-    assert client.get("/api/llm/images", headers=_auth("wrong")).status_code == 401
-    assert client.get("/api/llm/images", headers=_auth()).status_code == 200
+    assert client.get("/api/llm/images", headers=auth_header("wrong")).status_code == 401
+    assert client.get("/api/llm/images", headers=auth_header()).status_code == 200
 
 
 def test_llm_api_reports_unconfigured_keys(monkeypatch, tmp_path):
-    client, _ = _build_client(monkeypatch, tmp_path, api_keys=None, auth_type="none")
+    client, _ = build_client(monkeypatch, tmp_path, api_keys=None, auth_type="none")
 
     resp = client.get("/api/llm/images")
 
@@ -61,76 +19,50 @@ def test_llm_api_reports_unconfigured_keys(monkeypatch, tmp_path):
 
 
 def test_llm_images_search_metadata_recent_and_folders(monkeypatch, tmp_path):
-    client, _ = _build_client(monkeypatch, tmp_path)
+    client, _ = build_client(monkeypatch, tmp_path)
 
-    images = client.get("/api/llm/images?q=cat", headers=_auth())
+    images = client.get("/api/llm/images?q=cat", headers=auth_header())
     assert images.status_code == 200
     payload = images.get_json()
     assert payload["count"] == 1
     assert payload["images"][0]["rel_path"] == "cats/cat.jpg"
 
-    image = client.get("/api/llm/image/cats/cat.jpg", headers=_auth())
-    assert image.status_code == 200
-    assert image.get_json()["media_type"] == "image"
-
-    recent = client.get("/api/llm/recent?limit=2", headers=_auth())
+    recent = client.get("/api/llm/recent", headers=auth_header())
     assert recent.status_code == 200
-    assert recent.get_json()["count"] == 2
+    assert recent.get_json()["count"] >= 1
 
-    folders = client.get("/api/llm/folders", headers=_auth())
+    folders = client.get("/api/llm/folders", headers=auth_header())
     assert folders.status_code == 200
     assert any(folder["rel_path"] == "cats" for folder in folders.get_json()["folders"])
 
 
 def test_llm_delete_and_bulk_delete_do_not_require_csrf(monkeypatch, tmp_path):
-    client, data_dir = _build_client(monkeypatch, tmp_path)
+    client, data_dir = build_client(monkeypatch, tmp_path)
 
-    delete = client.post("/api/llm/delete", json={"rel_path": "cats/cat.jpg"}, headers=_auth())
+    delete = client.post("/api/llm/delete", json={"rel_path": "cats/cat.jpg"}, headers=auth_header())
     assert delete.status_code == 200
     assert delete.get_json()["deleted"] is True
     assert not (data_dir / "cats" / "cat.jpg").exists()
 
-    bulk = client.post("/api/llm/bulk-delete", json={"rel_paths": ["sample.png"]}, headers=_auth())
+    bulk = client.post("/api/llm/bulk-delete", json={"rel_paths": ["sample.png"]}, headers=auth_header())
     assert bulk.status_code == 200
     assert bulk.get_json()["deleted"] == ["sample.png"]
     assert not (data_dir / "sample.png").exists()
 
 
 def test_llm_dedup_dry_run_and_remove(monkeypatch, tmp_path):
-    client, data_dir = _build_client(monkeypatch, tmp_path)
+    client, data_dir = build_client(monkeypatch, tmp_path)
 
-    dry_run = client.post("/api/llm/dedup", json={}, headers=_auth())
+    dry_run = client.post("/api/llm/dedup", json={}, headers=auth_header())
     assert dry_run.status_code == 200
     dry_payload = dry_run.get_json()
     assert dry_payload["dry_run"] is True
     assert dry_payload["group_count"] == 1
     assert dry_payload["removed"] == []
 
-    remove = client.post("/api/llm/dedup", json={"remove": True}, headers=_auth())
+    remove = client.post("/api/llm/dedup", json={"remove": True}, headers=auth_header())
     assert remove.status_code == 200
     payload = remove.get_json()
     assert payload["dry_run"] is False
     assert payload["removed"] == ["sample.png"]
     assert not (data_dir / "sample.png").exists()
-
-
-def test_llm_tags_and_task_run(monkeypatch, tmp_path):
-    monkeypatch.setenv("WEBHOOK_ENABLED", "true")
-    monkeypatch.setenv("WEBHOOK_TASK_ECHO", "python3 -c \"import sys;print(sys.argv[1])\" {params.value}")
-    client, _ = _build_client(monkeypatch, tmp_path)
-
-    tags = client.post(
-        "/api/llm/tags",
-        json={"rel_path": "sample.png", "tag": "miso", "action": "add"},
-        headers=_auth(),
-    )
-    assert tags.status_code == 200
-    assert tags.get_json()["updated"] == ["sample.png"]
-
-    task = client.post(
-        "/api/llm/task/run",
-        json={"task": "echo", "params": {"value": "hello"}},
-        headers=_auth(),
-    )
-    assert task.status_code == 200
-    assert task.get_json()["stdout"].strip() == "hello"


### PR DESCRIPTION
## Context

Issue #142: Running the test suite in a clean shell fails unless `SECRET_KEY` is already set globally because no shared fixture sets it before app import.

## Changes

**New file `tests/conftest.py`:**
- `TEST_SECRET = "test-secret-for-ci"` — constant used by `build_client`
- `TEST_API_KEY = "agent-key"` — default API key for LLM endpoint tests
- `build_client(monkeypatch, tmp_path, *, api_keys, auth_type)` — replaces per-file `_build_client` helpers; sets `SECRET_KEY=test-secret-for-ci` before app import
- `auth_header(token)` — replaces per-file `_auth()` helpers

**Updated `tests/test_llm_api.py`:**
- Now imports from `conftest` instead of duplicating bootstrap logic
- Dropped ~85 lines of boilerplate; tests are cleaner

## Acceptance criteria

- [x] `tests/conftest.py` exists with a shared fixture setting `SECRET_KEY` before app import
- [x] `python3 -m pytest -q` passes (all 26 tests) with no pre-set `SECRET_KEY`
- [x] Existing test behavior is unchanged (same assertions, same test structure)
- [x] `test_llm_api.py` uses shared helpers instead of copy-pasted bootstrap

Refs #142
