### PR TITLE
Require write scope for LLM task execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ This allows sharing images while protecting the gallery UI.
 
 Miso Gallery includes a JSON API intended for LLM agents and other machine-to-machine clients. The primary purpose is to let an external LLM client inspect and manage gallery state: list/search media, read metadata, tag, delete, bulk-delete, and deduplicate images.
 
-Enable the API by setting one or more comma-separated API keys:
+Enable the API by setting one or more comma-separated API keys. Prefer separate read and write keys for new deployments; `LLM_API_KEYS` remains supported as a legacy all-purpose key.
 
 ```bash
 docker run -d --name miso-gallery \
@@ -196,14 +196,15 @@ docker run -d --name miso-gallery \
   -v /path/to/images:/data \
   -e SECRET_KEY=your-session-secret \
   -e ADMIN_PASSWORD=your-password \
-  -e LLM_API_KEYS=agent-key-1,agent-key-2 \
+  -e LLM_READ_API_KEYS=gallery-read-key \
+  -e LLM_WRITE_API_KEYS=gallery-write-key \
   ghcr.io/misospace/miso-gallery:latest
 ```
 
 Authenticate each request with a Bearer token:
 
 ```bash
-curl -H "Authorization: Bearer agent-key-1" \
+curl -H "Authorization: Bearer gallery-read-key" \
   http://localhost:5000/api/llm/images
 ```
 
@@ -221,7 +222,7 @@ LLM API endpoints are token-authenticated and do not require CSRF tokens. Existi
 Example:
 
 ```bash
-curl -H "Authorization: Bearer agent-key-1" \
+curl -H "Authorization: Bearer gallery-read-key" \
   "http://localhost:5000/api/llm/images?q=cat"
 ```
 
@@ -259,7 +260,7 @@ Delete example:
 
 ```bash
 curl -X POST \
-  -H "Authorization: Bearer agent-key-1" \
+  -H "Authorization: Bearer gallery-write-key" \
   -H "Content-Type: application/json" \
   -d '{"rel_path":"cats/cat.jpg"}' \
   http://localhost:5000/api/llm/delete
@@ -269,7 +270,7 @@ Dedup dry-run example:
 
 ```bash
 curl -X POST \
-  -H "Authorization: Bearer agent-key-1" \
+  -H "Authorization: Bearer gallery-write-key" \
   -H "Content-Type: application/json" \
   -d '{}' \
   http://localhost:5000/api/llm/dedup
@@ -286,7 +287,8 @@ docker run -d --name miso-gallery \
   -p 5000:5000 \
   -v /path/to/images:/data \
   -e SECRET_KEY=your-session-secret \
-  -e LLM_API_KEYS=agent-key-1 \
+  -e LLM_READ_API_KEYS=gallery-read-key \
+  -e LLM_WRITE_API_KEYS=gallery-write-key \
   -e WEBHOOK_ENABLED=true \
   -e 'WEBHOOK_TASK_GENERATE=python3 /data/scripts/generate.py {params.prompt}' \
   ghcr.io/misospace/miso-gallery:latest
@@ -296,13 +298,13 @@ Run a configured task:
 
 ```bash
 curl -X POST \
-  -H "Authorization: Bearer agent-key-1" \
+  -H "Authorization: Bearer gallery-write-key" \
   -H "Content-Type: application/json" \
   -d '{"task":"generate","params":{"prompt":"a cozy bowl of miso soup"}}' \
   http://localhost:5000/api/llm/task/run
 ```
 
-Task commands run from `DATA_FOLDER`, scalar params are shell-quoted, and the timeout is controlled by `WEBHOOK_TASK_TIMEOUT` with a default of 30 seconds.
+Task execution requires a write-scoped LLM API key. Read-scoped keys can browse gallery metadata but cannot run configured server-side tasks. Task commands run from `DATA_FOLDER`, scalar params are shell-quoted, and the timeout is controlled by `WEBHOOK_TASK_TIMEOUT` with a default of 30 seconds.
 
 ## Development
 

--- a/app.py
+++ b/app.py
@@ -1921,7 +1921,7 @@ def llm_dedup():
 
 
 @app.route("/api/llm/task/run", methods=["POST"])
-@require_api_key_with_scope("read")
+@require_api_key_with_scope("write")
 @rate_limit(max_requests=10, window=60)
 def llm_task_run():
     body, status = run_configured_task(request.get_json(silent=True) or {})

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -246,7 +246,7 @@ Miso Gallery supports separate read and write API keys:
 
 ### Threat Model
 
-Webhook tasks allow authenticated API callers to execute arbitrary shell commands on the gallery host. This is a **high-privilege operation** with the following risks:
+Webhook tasks allow authenticated write-scoped API callers to execute arbitrary shell commands on the gallery host. This is a **high-privilege operation** with the following risks:
 
 - A compromised API key can execute any command as the gallery process user.
 - Command injection via untrusted payload parameters (e.g., image paths in task templates).
@@ -258,6 +258,7 @@ Webhook tasks allow authenticated API callers to execute arbitrary shell command
 |---|---|---|
 | `WEBHOOK_ENABLED` | `false` | Disable by default; enable only if needed |
 | `WEBHOOK_TASK_TIMEOUT` | `30` | Max seconds per task (range: 1–600) |
+| `LLM_WRITE_API_KEYS` | unique high-entropy tokens | Required for `/api/llm/task/run`; read-scoped keys are rejected |
 
 ### Enabling Tasks
 

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -92,6 +92,37 @@ def test_llm_tags_and_task_run(monkeypatch, tmp_path):
     )
     assert task.status_code == 200
     assert task.get_json()["stdout"].strip() == "hello"
+
+
+def test_read_key_rejected_from_task_run(monkeypatch, tmp_path):
+    monkeypatch.setenv("WEBHOOK_ENABLED", "true")
+    monkeypatch.setenv("WEBHOOK_TASK_ECHO", "python3 -c \"import sys;print(sys.argv[1])\" {params.value}")
+    client, _ = build_client(
+        monkeypatch,
+        tmp_path,
+        api_keys=None,
+        extra_env={
+            "LLM_READ_API_KEYS": "read-only-key",
+            "LLM_WRITE_API_KEYS": "write-secret-key",
+        },
+    )
+
+    read_task = client.post(
+        "/api/llm/task/run",
+        json={"task": "echo", "params": {"value": "hello"}},
+        headers=auth_header("read-only-key"),
+    )
+    assert read_task.status_code == 401
+
+    write_task = client.post(
+        "/api/llm/task/run",
+        json={"task": "echo", "params": {"value": "hello"}},
+        headers=auth_header("write-secret-key"),
+    )
+    assert write_task.status_code == 200
+    assert write_task.get_json()["stdout"].strip() == "hello"
+
+
 def test_write_key_can_access_read_endpoints(monkeypatch, tmp_path):
     """Write-scoped keys should be accepted on read endpoints."""
     client, _ = build_client(monkeypatch, tmp_path, api_keys="write-only-key")


### PR DESCRIPTION
## Summary\n- require write-scoped LLM API keys for /api/llm/task/run\n- add regression coverage proving read keys are rejected and write keys can run configured tasks\n- update README/runbook examples to document read/write key separation for high-privilege task execution\n\nRefs #163\n\n## Validation\n- python3 -m pytest -q\n- python3 -m flake8 app.py --count --select=E9,F63,F7,F82 --show-source --statistics