### PR TITLE
fix: bound recursive gallery scans before pagination

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,14 +125,18 @@ _FOLDER_COVER_CACHE: dict[str, tuple[float, str | None]] = {}
 # Bounded pagination defaults for gallery endpoints
 GALLERY_PAGE_DEFAULT = 50
 GALLERY_PAGE_MAX = 500
+import os
+GALLERY_SCAN_LIMIT = int(os.environ.get("GALLERY_SCAN_LIMIT", "5000"))
 
 
 def _paginate(items, page=1, per_page=GALLERY_PAGE_DEFAULT):
-    """Return (paginated_items, total_count, page, per_page)."""
+    """Return (paginated_items, total_count, page, per_page, has_more)."""
     total = len(items)
     start = (page - 1) * per_page
     end = start + per_page
-    return items[start:end], total, page, per_page
+    paginated = items[start:end]
+    has_more = end < total
+    return paginated, total, page, per_page, has_more
 
 
 def _parse_pagination(args):
@@ -1059,10 +1063,11 @@ def media_metadata(path: Path) -> dict[str, object]:
 
 
 def iter_gallery_media(limit: int | None = None) -> list[Path]:
-    """Iterate gallery media files, optionally bounded by limit."""
+    """Iterate gallery media files, bounded by scan limit."""
+    effective_limit = limit if limit is not None else GALLERY_SCAN_LIMIT
     media: list[Path] = []
     for item in DATA_FOLDER.rglob("*"):
-        if limit is not None and len(media) >= limit:
+        if len(media) >= effective_limit:
             break
         try:
             if is_media_file(item) and not is_excluded_gallery_path(item):
@@ -1073,10 +1078,11 @@ def iter_gallery_media(limit: int | None = None) -> list[Path]:
 
 
 def iter_gallery_folders(limit: int | None = None) -> list[Path]:
-    """Iterate gallery folders, optionally bounded by limit."""
+    """Iterate gallery folders, bounded by scan limit."""
+    effective_limit = limit if limit is not None else GALLERY_SCAN_LIMIT
     folders: list[Path] = []
     for item in DATA_FOLDER.rglob("*"):
-        if limit is not None and len(folders) >= limit:
+        if len(folders) >= effective_limit:
             break
         try:
             if item.is_dir() and not is_excluded_gallery_path(item):
@@ -1776,8 +1782,12 @@ def llm_images():
         if query and query not in rel_path.lower() and query not in item.name.lower():
             continue
         filtered.append(media_metadata(item))
-    paginated, total, pg, pp = _paginate(filtered, page=page, per_page=per_page)
-    return {"images": paginated, "count": len(paginated), "total": total, "page": pg, "per_page": pp}
+    paginated, total, pg, pp, has_more = _paginate(filtered, page=page, per_page=per_page)
+    # If scan hit the limit, there may be more unscanned items matching the query
+    scan_limited = len(all_media) >= GALLERY_SCAN_LIMIT
+    if scan_limited and not has_more:
+        has_more = True
+    return {"images": paginated, "count": len(paginated), "total": total, "page": pg, "per_page": pp, "has_more": has_more}
 
 
 @app.route("/api/llm/image/<path:relpath>")
@@ -1798,8 +1808,12 @@ def llm_image(relpath: str):
 def llm_recent():
     page, per_page = _parse_pagination(request.args)
     all_media = sorted(iter_gallery_media(), key=lambda p: p.stat().st_mtime, reverse=True)
-    paginated, total, pg, pp = _paginate(all_media, page=page, per_page=per_page)
-    return {"images": [media_metadata(item) for item in paginated], "count": len(paginated), "total": total, "page": pg, "per_page": pp}
+    paginated, total, pg, pp, has_more = _paginate(all_media, page=page, per_page=per_page)
+    # If scan hit the limit, there may be more recent items beyond the scan window
+    scan_limited = len(all_media) >= GALLERY_SCAN_LIMIT
+    if scan_limited and not has_more:
+        has_more = True
+    return {"images": [media_metadata(item) for item in paginated], "count": len(paginated), "total": total, "page": pg, "per_page": pp, "has_more": has_more}
 
 
 @app.route("/api/llm/folders")
@@ -1812,8 +1826,11 @@ def llm_folders():
         rel_path = folder.relative_to(DATA_FOLDER).as_posix()
         parent = folder.parent.relative_to(DATA_FOLDER).as_posix() if folder.parent != DATA_FOLDER else ""
         all_folders.append({"rel_path": rel_path, "name": folder.name, "parent": parent})
-    paginated, total, pg, pp = _paginate(all_folders, page=page, per_page=per_page)
-    return {"folders": paginated, "count": len(paginated), "total": total, "page": pg, "per_page": pp}
+    paginated, total, pg, pp, has_more = _paginate(all_folders, page=page, per_page=per_page)
+    scan_limited = len(all_folders) - 1 >= GALLERY_SCAN_LIMIT  # -1 for root entry
+    if scan_limited and not has_more:
+        has_more = True
+    return {"folders": paginated, "count": len(paginated), "total": total, "page": pg, "per_page": pp, "has_more": has_more}
 
 
 @app.route("/api/llm/tags", methods=["POST"])

--- a/tests/test_bounded_scans.py
+++ b/tests/test_bounded_scans.py
@@ -1,0 +1,183 @@
+"""Tests for bounded gallery scans (issue #167).
+
+Verifies that LLM endpoints and iterator functions respect scan limits
+and return has_more when the scan was truncated.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _build_bounded_client(monkeypatch, tmp_path):
+    """Build a test client with a low scan limit for testing."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / ".thumb_cache").mkdir(exist_ok=True)
+
+    # Write many media files to exceed the scan limit
+    for i in range(6000):
+        path = data_dir / f"img_{i:05d}.png"
+        path.write_bytes(b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\xcf\xc0\x00\x00\x03\x01\x01\x00\xc9\xfe\x92\xef\x00\x00\x00\x00IEND\xaeB`\x82')
+
+    # Write many subdirectories
+    for i in range(6000):
+        (data_dir / f"subdir_{i:05d}").mkdir()
+
+    monkeypatch.setenv("GALLERY_SCAN_LIMIT", "50")
+    monkeypatch.setenv("DATA_FOLDER", str(data_dir))
+    monkeypatch.setenv("AUTH_TYPE", "local")
+    monkeypatch.setenv("ADMIN_PASSWORD", "pass123")
+    monkeypatch.setenv("OIDC_ENABLED", "false")
+    monkeypatch.setenv("SECRET_KEY", "test-secret-ci-gateway")
+    monkeypatch.setenv("LLM_API_KEYS", "agent-key")
+
+    for mod in ("auth", "app"):
+        sys.modules.pop(mod, None)
+
+    import app as app_module
+    app_module.DATA_FOLDER = data_dir
+    app_module.THUMBNAIL_CACHE_DIR = data_dir / ".thumb_cache"
+    app_module.app.config["TESTING"] = True
+
+    return app_module.app.test_client(), data_dir
+
+
+def _api_header():
+    return {"Authorization": "Bearer agent-key"}
+
+
+class TestIterGalleryMediaBounded:
+    """iter_gallery_media should never exceed GALLERY_SCAN_LIMIT."""
+
+    def test_respects_scan_limit(self, monkeypatch, tmp_path):
+        client, data_dir = _build_bounded_client(monkeypatch, tmp_path)
+
+        import app as app_module
+        media = app_module.iter_gallery_media()
+        assert len(media) <= 50  # GALLERY_SCAN_LIMIT is set to 50
+
+    def test_custom_limit_works(self, monkeypatch, tmp_path):
+        client, data_dir = _build_bounded_client(monkeypatch, tmp_path)
+
+        import app as app_module
+        media = app_module.iter_gallery_media(limit=10)
+        assert len(media) <= 10
+
+
+class TestIterGalleryFoldersBounded:
+    """iter_gallery_folders should never exceed GALLERY_SCAN_LIMIT."""
+
+    def test_respects_scan_limit(self, monkeypatch, tmp_path):
+        client, data_dir = _build_bounded_client(monkeypatch, tmp_path)
+
+        import app as app_module
+        folders = app_module.iter_gallery_folders()
+        assert len(folders) <= 50
+
+    def test_custom_limit_works(self, monkeypatch, tmp_path):
+        client, data_dir = _build_bounded_client(monkeypatch, tmp_path)
+
+        import app as app_module
+        folders = app_module.iter_gallery_folders(limit=20)
+        assert len(folders) <= 20
+
+
+class TestLlmImagesHasMore:
+    """llm_images should return has_more=True when scan is limited."""
+
+    def test_has_more_when_scan_limited(self, monkeypatch, tmp_path):
+        client, data_dir = _build_bounded_client(monkeypatch, tmp_path)
+
+        resp = client.get("/api/llm/images", headers=_api_header())
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # With 6000 images and scan limit 50, should report has_more
+        assert data["has_more"] is True
+
+    def test_has_more_false_when_not_limited(self, monkeypatch, tmp_path):
+        """When gallery is small enough, has_more should be False."""
+        data_dir = tmp_path / "small_data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / ".thumb_cache").mkdir(exist_ok=True)
+
+        # Only 10 images - well under the default limit of 5000
+        for i in range(10):
+            (data_dir / f"img_{i:03d}.png").write_bytes(b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\xcf\xc0\x00\x00\x03\x01\x01\x00\xc9\xfe\x92\xef\x00\x00\x00\x00IEND\xaeB`\x82')
+
+        monkeypatch.setenv("DATA_FOLDER", str(data_dir))
+        monkeypatch.setenv("AUTH_TYPE", "local")
+        monkeypatch.setenv("ADMIN_PASSWORD", "pass123")
+        monkeypatch.setenv("OIDC_ENABLED", "false")
+        monkeypatch.setenv("SECRET_KEY", "test-secret-ci-gateway")
+        monkeypatch.setenv("LLM_API_KEYS", "agent-key")
+
+        for mod in ("auth", "app"):
+            sys.modules.pop(mod, None)
+
+        import app as app_module
+        app_module.DATA_FOLDER = data_dir
+        app_module.THUMBNAIL_CACHE_DIR = data_dir / ".thumb_cache"
+        app_module.app.config["TESTING"] = True
+
+        resp = app_module.app.test_client().get("/api/llm/images", headers=_api_header())
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["has_more"] is False
+
+
+class TestLlmRecentHasMore:
+    """llm_recent should return has_more=True when scan is limited."""
+
+    def test_has_more_when_scan_limited(self, monkeypatch, tmp_path):
+        client, data_dir = _build_bounded_client(monkeypatch, tmp_path)
+
+        resp = client.get("/api/llm/recent", headers=_api_header())
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["has_more"] is True
+
+
+class TestLlmFoldersHasMore:
+    """llm_folders should return has_more=True when scan is limited."""
+
+    def test_has_more_when_scan_limited(self, monkeypatch, tmp_path):
+        client, data_dir = _build_bounded_client(monkeypatch, tmp_path)
+
+        resp = client.get("/api/llm/folders", headers=_api_header())
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["has_more"] is True
+
+
+class TestFindDuplicateMediaBounded:
+    """find_duplicate_media should respect scan limits."""
+
+    def test_respects_scan_limit(self, monkeypatch, tmp_path):
+        """Even with many duplicates in the filesystem, only scan up to limit."""
+        client, data_dir = _build_bounded_client(monkeypatch, tmp_path)
+
+        import app as app_module
+        groups = app_module.find_duplicate_media()
+        # With scan limit 50 and all identical images, at most one group
+        assert len(groups) >= 0
+        # The function should not crash or hang on large galleries
+
+
+class TestScanLimitConstant:
+    """Verify GALLERY_SCAN_LIMIT is properly defined."""
+
+    def test_default_value(self, monkeypatch):
+        monkeypatch.delenv("GALLERY_SCAN_LIMIT", raising=False)
+        sys.modules.pop("app", None)
+        import app as app_module
+        assert hasattr(app_module, "GALLERY_SCAN_LIMIT")
+        assert app_module.GALLERY_SCAN_LIMIT == 5000


### PR DESCRIPTION
Fixes #167

Bound recursive gallery scans to prevent blocking workers on large galleries or NFS mounts.

**Changes:**
- Add `GALLERY_SCAN_LIMIT` constant (default 5000, configurable via `GALLERY_SCAN_LIMIT` env var)
- `iter_gallery_media()` and `iter_gallery_folders()` now always respect scan limits instead of traversing the entire filesystem
- `_paginate()` returns a `has_more` flag alongside existing values
- `llm_images`, `llm_recent`, `llm_folders` endpoints return `has_more=True` when scan was truncated, allowing clients to know more data exists
- `find_duplicate_media()` respects scan bounds via bounded `iter_gallery_media()`

**Acceptance criteria:**
- ✅ Add traversal/indexing boundaries (max-scan limits)
- ✅ Responses expose `has_more` when limits are hit
- ✅ Tests cover bounded behavior (10 new tests)