### PR TITLE
fix: split storage read and write health probes

### DIFF
--- a/health.py
+++ b/health.py
@@ -83,9 +83,8 @@ def update_unhealthy_signal(health: dict[str, Any]) -> None:
         pass
 
 
-def get_storage_health() -> dict[str, Any]:
-    """Get comprehensive storage health status."""
-    health: dict[str, Any] = {
+def _new_health_payload() -> dict[str, Any]:
+    return {
         "status": "healthy",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "checks": {
@@ -93,6 +92,56 @@ def get_storage_health() -> dict[str, Any]:
             "thumbnail_cache": {},
         },
     }
+
+
+def get_storage_read_health() -> dict[str, Any]:
+    """Get read-only storage health status without write probes or signal updates."""
+    health: dict[str, Any] = _new_health_payload()
+
+    read_ok, read_msg = check_storage_read(DATA_FOLDER)
+    health["checks"]["data_folder"]["read"] = {
+        "ok": read_ok,
+        "message": read_msg,
+    }
+
+    thumb_read_ok, thumb_read_msg = check_storage_read(THUMBNAIL_CACHE_DIR)
+    health["checks"]["thumbnail_cache"]["read"] = {
+        "ok": thumb_read_ok,
+        "message": thumb_read_msg,
+    }
+
+    if not (read_ok and thumb_read_ok):
+        health["status"] = "unhealthy"
+
+    return health
+
+
+def get_storage_write_health() -> dict[str, Any]:
+    """Get write-probe storage health status."""
+    health: dict[str, Any] = _new_health_payload()
+
+    write_ok, write_msg = check_storage_write(DATA_FOLDER)
+    health["checks"]["data_folder"]["write"] = {
+        "ok": write_ok,
+        "message": write_msg,
+    }
+
+    thumb_write_ok, thumb_write_msg = check_storage_write(THUMBNAIL_CACHE_DIR)
+    health["checks"]["thumbnail_cache"]["write"] = {
+        "ok": thumb_write_ok,
+        "message": thumb_write_msg,
+    }
+
+    if not (write_ok and thumb_write_ok):
+        health["status"] = "unhealthy"
+
+    update_unhealthy_signal(health)
+    return health
+
+
+def get_storage_health() -> dict[str, Any]:
+    """Get comprehensive storage health status."""
+    health: dict[str, Any] = _new_health_payload()
 
     read_ok, read_msg = check_storage_read(DATA_FOLDER)
     health["checks"]["data_folder"]["read"] = {
@@ -136,7 +185,7 @@ def storage_health() -> tuple[Any, int]:
 @health_bp.route("/health/storage/read")
 def storage_health_read() -> tuple[Any, int]:
     """Return read-only storage health status."""
-    health = get_storage_health()
+    health = get_storage_read_health()
     status_code = 200 if health["status"] == "healthy" else 503
     return jsonify({
         "status": health["status"],
@@ -151,7 +200,7 @@ def storage_health_read() -> tuple[Any, int]:
 @health_bp.route("/health/storage/write")
 def storage_health_write() -> tuple[Any, int]:
     """Return write-capable storage health status."""
-    health = get_storage_health()
+    health = get_storage_write_health()
     status_code = 200 if health["status"] == "healthy" else 503
     return jsonify({
         "status": health["status"],

--- a/tests/test_storage_health.py
+++ b/tests/test_storage_health.py
@@ -61,3 +61,66 @@ def test_healthy_clears_existing_signal_file(monkeypatch, tmp_path):
 
     assert result["status"] == "healthy"
     assert not signal.exists()
+
+
+def test_read_health_does_not_run_write_probe_or_touch_signal(monkeypatch, tmp_path):
+    data = tmp_path / "data"
+    thumb = data / ".thumb_cache"
+    data.mkdir()
+    thumb.mkdir()
+    signal = tmp_path / "storage-unhealthy.signal"
+    signal.write_text("existing signal", encoding="utf-8")
+
+    monkeypatch.setattr(health, "DATA_FOLDER", data)
+    monkeypatch.setattr(health, "THUMBNAIL_CACHE_DIR", thumb)
+    monkeypatch.setattr(health, "STORAGE_HEALTH_SIGNAL_FILE", signal)
+
+    read_paths = []
+
+    def fake_read(path: Path):
+        read_paths.append(path)
+        return True, "Read OK"
+
+    def fail_if_written(_path: Path):
+        raise AssertionError("read health must not run write probes")
+
+    monkeypatch.setattr(health, "check_storage_read", fake_read)
+    monkeypatch.setattr(health, "check_storage_write", fail_if_written)
+
+    result = health.get_storage_read_health()
+
+    assert result["status"] == "healthy"
+    assert read_paths == [data, thumb]
+    assert set(result["checks"]["data_folder"]) == {"read"}
+    assert set(result["checks"]["thumbnail_cache"]) == {"read"}
+    assert signal.read_text(encoding="utf-8") == "existing signal"
+
+
+def test_write_health_runs_write_probe_and_updates_signal(monkeypatch, tmp_path):
+    data = tmp_path / "data"
+    thumb = data / ".thumb_cache"
+    data.mkdir()
+    thumb.mkdir()
+    signal = tmp_path / "storage-unhealthy.signal"
+
+    monkeypatch.setattr(health, "DATA_FOLDER", data)
+    monkeypatch.setattr(health, "THUMBNAIL_CACHE_DIR", thumb)
+    monkeypatch.setattr(health, "STORAGE_HEALTH_SIGNAL_FILE", signal)
+
+    def fail_if_read(_path: Path):
+        raise AssertionError("write health should not run read probes")
+
+    def fake_write(path: Path):
+        if path == thumb:
+            return False, "Write failed"
+        return True, "Write OK"
+
+    monkeypatch.setattr(health, "check_storage_read", fail_if_read)
+    monkeypatch.setattr(health, "check_storage_write", fake_write)
+
+    result = health.get_storage_write_health()
+
+    assert result["status"] == "unhealthy"
+    assert set(result["checks"]["data_folder"]) == {"write"}
+    assert set(result["checks"]["thumbnail_cache"]) == {"write"}
+    assert signal.exists()


### PR DESCRIPTION
Fixes #169

## Summary
- split read-only storage health into a read-only helper used by `/health/storage/read`
- split write probes into a write-specific helper used by `/health/storage/write`
- add tests proving read health avoids write probes/signal changes and write health still verifies writeability

## Validation
- `pytest tests/test_storage_health.py -q`
- `pytest -q`
