### PR TITLE
fix: clarify LLM read/write key scope semantics (#166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ docker run -d \
 | `AUTH_TYPE` | No | `local` | Auth method: `local`, `oidc`, or `none` |
 | `ADMIN_PASSWORD` | If local | - | Password for local auth (plaintext or Werkzeug hash: `pbkdf2:` / `scrypt:`) |
 | `SECRET_KEY` | Yes | - | Flask secret for sessions. Generate with: `python -c "import secrets; print(secrets.token_urlsafe(48))"` |
-| `LLM_API_KEYS` | No | - | Comma-separated Bearer tokens for the LLM API (`Authorization: Bearer <token>`) |
+| `LLM_READ_API_KEYS` | No | - | Comma-separated Bearer tokens with **read scope** (list, view, thumbnails). Write-scoped keys are also accepted here. |
+| `LLM_WRITE_API_KEYS` | No | - | Comma-separated Bearer tokens with **write scope** (delete, dedup, bulk operations, task execution). |
+| `LLM_API_KEYS` | No | — | Legacy single var; functions as both read and write. Deprecated in favour of `LLM_READ_API_KEYS` / `LLM_WRITE_API_KEYS`. |
 | `OIDC_ISSUER` | If OIDC | - | OIDC provider URL (e.g., https://authentik.example.com) |
 | `OIDC_CLIENT_ID` | If OIDC | - | OIDC client ID |
 | `OIDC_CLIENT_SECRET` | If OIDC | - | OIDC client secret |
@@ -188,7 +190,13 @@ This allows sharing images while protecting the gallery UI.
 
 Miso Gallery includes a JSON API intended for LLM agents and other machine-to-machine clients. The primary purpose is to let an external LLM client inspect and manage gallery state: list/search media, read metadata, tag, delete, bulk-delete, and deduplicate images.
 
-Enable the API by setting one or more comma-separated API keys. Prefer separate read and write keys for new deployments; `LLM_API_KEYS` remains supported as a legacy all-purpose key.
+Enable the API by configuring one or more API keys. The desired model:
+
+- **Read keys** (`LLM_READ_API_KEYS`) grant access to list, view, and thumbnail endpoints.
+- **Write keys** (`LLM_WRITE_API_KEYS`) grant access to delete, dedup, bulk operations, and task execution. A write key also works on read endpoints (write implies read).
+- **Legacy keys** (`LLM_API_KEYS`) function as both read and write — supported for backward compatibility but deprecated.
+
+Prefer separate read and write keys for new deployments; `LLM_API_KEYS` remains supported as a legacy all-purpose key. When explicit `LLM_READ_API_KEYS` or `LLM_WRITE_API_KEYS` are set, the legacy `LLM_API_KEYS` value is ignored.
 
 ```bash
 docker run -d --name miso-gallery \

--- a/auth.py
+++ b/auth.py
@@ -103,10 +103,12 @@ def _keys_for_scope(scope: Literal["read", "write"]) -> list[str]:
         if LLM_WRITE_API_KEYS:
             return LLM_WRITE_API_KEYS
         return _LLM_LEGACY_KEYS
-    # Read scope: explicit read keys, then legacy
-    if LLM_READ_API_KEYS:
-        return LLM_READ_API_KEYS
-    return _LLM_LEGACY_KEYS
+    # Read scope: explicit read keys, write keys (write implies read), then legacy
+    keys = list(LLM_READ_API_KEYS)
+    keys.extend(LLM_WRITE_API_KEYS)
+    if not keys:
+        keys = list(_LLM_LEGACY_KEYS)
+    return keys
 
 
 def verify_api_key_scope(token: str, scope: Literal["read", "write"]) -> bool:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -215,11 +215,18 @@ If OIDC login is broken:
 
 ### API Key Rotation
 
-Miso Gallery supports separate read and write API keys:
+Miso Gallery supports separate read and write API keys. The desired model:
 
-- `LLM_READ_API_KEYS` — comma-separated keys with read scope (list, view, thumbnails)
-- `LLM_WRITE_API_KEYS` — comma-separated keys with write scope (delete, dedup, bulk operations)
-- `LLM_API_KEYS` — legacy single var (both read and write); deprecated but still supported
+| Variable | Scope | Endpoints |
+|---|---|---|
+| `LLM_READ_API_KEYS` | Read only | List, view, thumbnails, search |
+| `LLM_WRITE_API_KEYS` | Write (implies read) | Delete, dedup, bulk operations, task execution + all read endpoints |
+| `LLM_API_KEYS` | Both (legacy) | All endpoints; deprecated in favour of explicit keys |
+
+**Key rules:**
+- A write key is accepted on both read and write endpoints.
+- A read-only key is rejected from write endpoints.
+- When explicit `LLM_READ_API_KEYS` or `LLM_WRITE_API_KEYS` are set, the legacy `LLM_API_KEYS` value is ignored.
 
 **To rotate keys:**
 

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -230,3 +230,121 @@ def test_llm_delete_dry_run(monkeypatch, tmp_path):
     actual = client.post("/api/llm/delete", json={"rel_path": "cats/cat.jpg"}, headers=auth_header())
     assert actual.status_code == 200
     assert not (data_dir / "cats" / "cat.jpg").exists()
+
+
+def test_legacy_llm_api_keys_work_as_both_read_and_write(monkeypatch, tmp_path):
+    """Legacy LLM_API_KEYS should function as both read and write keys.
+
+    This ensures backward compatibility: a single LLM_API_KEYS value
+    grants full access (read + write), matching the documented legacy behavior.
+    """
+    client, data_dir = build_client(
+        monkeypatch,
+        tmp_path,
+        api_keys="legacy-all-access-key",
+        extra_env={
+            "LLM_READ_API_KEYS": "",
+            "LLM_WRITE_API_KEYS": "",
+        },
+    )
+
+    # Legacy key should work on read endpoints
+    images = client.get("/api/llm/images", headers=auth_header("legacy-all-access-key"))
+    assert images.status_code == 200
+
+    # Legacy key should also work on write endpoints
+    delete = client.post(
+        "/api/llm/delete",
+        json={"rel_path": "sample.png"},
+        headers=auth_header("legacy-all-access-key"),
+    )
+    assert delete.status_code == 200
+    assert delete.get_json()["deleted"] is True
+    assert not (data_dir / "sample.png").exists()
+
+
+def test_explicit_read_keys_only_rejects_write(monkeypatch, tmp_path):
+    """When only LLM_READ_API_KEYS is set, write endpoints should be rejected."""
+    client, data_dir = build_client(
+        monkeypatch,
+        tmp_path,
+        api_keys=None,
+        extra_env={
+            "LLM_READ_API_KEYS": "read-only-key",
+            "LLM_WRITE_API_KEYS": "",
+        },
+    )
+
+    # Read should work
+    images = client.get("/api/llm/images", headers=auth_header("read-only-key"))
+    assert images.status_code == 200
+
+    # Write should be rejected (no write keys configured)
+    delete = client.post(
+        "/api/llm/delete",
+        json={"rel_path": "sample.png"},
+        headers=auth_header("read-only-key"),
+    )
+    assert delete.status_code == 403
+    assert "Write API keys are not configured" in delete.get_json()["error"]
+
+
+def test_mixed_keys_respect_scope_boundaries(monkeypatch, tmp_path):
+    """When both explicit read and write keys are set, legacy fallback is bypassed."""
+    client, data_dir = build_client(
+        monkeypatch,
+        tmp_path,
+        api_keys=None,
+        extra_env={
+            "LLM_API_KEYS": "legacy-key",  # should be ignored when explicit keys exist
+            "LLM_READ_API_KEYS": "explicit-read",
+            "LLM_WRITE_API_KEYS": "explicit-write",
+        },
+    )
+
+    # Explicit read key works on read endpoints
+    images = client.get("/api/llm/images", headers=auth_header("explicit-read"))
+    assert images.status_code == 200
+
+    # Explicit write key works on read endpoints (write implies read)
+    images_w = client.get("/api/llm/images", headers=auth_header("explicit-write"))
+    assert images_w.status_code == 200
+
+    # Write key works on write endpoints
+    delete_w = client.post(
+        "/api/llm/delete",
+        json={"rel_path": "sample.png"},
+        headers=auth_header("explicit-write"),
+    )
+    assert delete_w.status_code == 200
+    assert not (data_dir / "sample.png").exists()
+
+    # Legacy key should NOT work when explicit read+write keys are configured
+    images_legacy = client.get("/api/llm/images", headers=auth_header("legacy-key"))
+    assert images_legacy.status_code == 401
+
+    # Read-only key should NOT work on write endpoints
+    delete_read = client.post(
+        "/api/llm/delete",
+        json={"rel_path": "copy.png"},
+        headers=auth_header("explicit-read"),
+    )
+    assert delete_read.status_code == 401
+
+
+def test_write_only_key_can_access_read_endpoints(monkeypatch, tmp_path):
+    """When only LLM_WRITE_API_KEYS is set (no explicit read keys),
+    write keys should be accepted on read endpoints since write implies read."""
+    client, _ = build_client(
+        monkeypatch,
+        tmp_path,
+        api_keys=None,
+        extra_env={
+            "LLM_READ_API_KEYS": "",
+            "LLM_WRITE_API_KEYS": "write-only-key",
+        },
+    )
+
+    # Write key should work on read endpoints (write implies read)
+    images = client.get("/api/llm/images", headers=auth_header("write-only-key"))
+    assert images.status_code == 200


### PR DESCRIPTION
Fixes #166

Clarify and align the LLM API key read/write model across implementation, tests, and documentation.

## Changes

### Implementation ()
- **Write keys now accepted on read endpoints** — write implies read access. Previously, explicit  were only checked for write scope, causing them to be rejected on read endpoints.
- Read scope now checks: explicit read keys → write keys (write implies read) → legacy fallback.

### Tests ()
Added 4 new tests covering all key configuration scenarios:
-  — legacy  grants full access
-  — read-only keys blocked on write endpoints (403)
-  — explicit keys bypass legacy fallback; scope boundaries enforced
-  — write-only keys work on read endpoints

### Documentation
- **README.md**: Replaced single  row with explicit read/write key table entries and added a clear model description section.
- **docs/runbook.md**: Added scope table, key rules, and clarified legacy fallback behavior.

## Acceptance Criteria
- ✅ Desired read/write model is documented (README.md + docs/runbook.md)
- ✅  behavior matches the documented model (write implies read)
- ✅ Tests cover explicit , , and legacy 