### PR TITLE
chore: bump APP_VERSION from 0.1.16 to 0.1.17

### DIFF
--- a/app.py
+++ b/app.py
@@ -130,7 +130,7 @@ FAVICON_URL = os.environ.get("FAVICON_URL", "").strip()
 
 PWA_THEME_COLOR = "#0d0d0d"
 PWA_APP_NAME = "Miso Gallery"
-APP_VERSION = (os.environ.get("APP_VERSION") or "0.1.16").strip() or "0.1.16"
+APP_VERSION = (os.environ.get("APP_VERSION") or "0.1.17").strip() or "0.1.17"
 WEBHOOK_TASK_PREFIX = "WEBHOOK_TASK_"
 AUTO_FOLDER_COVERS_ENABLED = os.environ.get("GALLERY_AUTO_FOLDER_COVERS", "false").strip().lower() in {"1", "true", "yes", "on"}
 FOLDER_COVER_CACHE_TTL = max(int(os.environ.get("GALLERY_COVER_CACHE_TTL", "3600") or 3600), 0)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -59,7 +59,7 @@ GET /health
 ```json
 {
   "status": "healthy",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "timestamp": "2026-05-18T09:00:00+00:00",
   "storage": {
     "status": "healthy",


### PR DESCRIPTION
Bump in-app version for next release.

All audit findings from #163 have been resolved:
- P1: task run write scope (#165 / PR #164)
- P1/P2: key scope semantics (#166 / PR #173)
- P1: bounded scans (#167 / PR #171)
- P2: folder bulk trash (#168 / PR #170)
- P2: storage health split (#169 / PR #172)
- P2: CI hygiene (#146 / PR #174)

Ready for merge.