### PR TITLE
fix: anchor APP_VERSION grep in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           set -euo pipefail
           TAG="${{ github.event.release.tag_name }}"
           TAG="${TAG#v}"
-          VERSION=$(grep 'APP_VERSION' app.py | grep -oP 'or "\K[^"]+')
+          VERSION=$(grep '^APP_VERSION = ' app.py | head -1 | grep -oP 'or "\K[^"]+' | head -1)
           if [ "$VERSION" != "$TAG" ]; then
             echo "ERROR: APP_VERSION ($VERSION) does not match release tag ($TAG)"
             echo "The APP_VERSION constant in app.py must be bumped to $TAG before releasing."


### PR DESCRIPTION
Fixes #181

The previous `grep 'APP_VERSION' app.py` matched 3 lines (1 assignment + 2 usages), and the assignment line contains two `or "..."` patterns, causing duplicate matches.

**Fix:** Anchor to `'^APP_VERSION = '` to target only the assignment line.
