### PR TITLE
fix: align llm_dedup response schema with llm_bulk_delete

### DIFF
--- a/app.py
+++ b/app.py
@@ -1943,7 +1943,9 @@ def llm_dedup():
                     remove_thumbnail_cache_for(str(rel_path))
                     removed.append(str(rel_path))
     log_security_event("llm_dedup", "success", groups=len(groups), removed=len(removed), dry_run=not remove)
-    return {"duplicate_groups": groups, "group_count": len(groups), "dry_run": not remove, "removed": removed}
+    if remove:
+        return {"duplicate_groups": groups, "group_count": len(groups), "dry_run": False, "removed": removed, "deleted_count": len(removed)}
+    return {"duplicate_groups": groups, "group_count": len(groups), "dry_run": True, "skipped_count": 0, "deleted_count": 0}
 
 
 @app.route("/api/llm/task/run", methods=["POST"])

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -62,7 +62,9 @@ def test_llm_dedup_dry_run_and_remove(monkeypatch, tmp_path):
     dry_payload = dry_run.get_json()
     assert dry_payload["dry_run"] is True
     assert dry_payload["group_count"] == 1
-    assert dry_payload["removed"] == []
+    assert "removed" not in dry_payload
+    assert "deleted_count" in dry_payload
+    assert "skipped_count" in dry_payload
 
     remove = client.post("/api/llm/dedup", json={"remove": True}, headers=auth_header())
     assert remove.status_code == 200


### PR DESCRIPTION
Fixes #183

Align `llm_dedup` and `llm_bulk_delete` response schemas as recommended in the May 27 tech debt audit.

Changes:
- Add `deleted_count`/`skipped_count` fields to dedup response for schema alignment with bulk_delete
- Omit `removed` field from dry_run responses (was always `[]` and misleading for LLM consumers)
- Update test to verify new aligned fields