### PR TITLE
ci: Change Python from 3.14 to 3.12 in CI workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.14'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install dependencies

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.14'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install dependencies


### PR DESCRIPTION
Fixes #185

Change CI Python version from 3.14 (development) to 3.12 for stability.

Python 3.14 is not yet stable (expected October 2026). Using it risks spurious CI failures from breaking stdlib changes, C extension incompatibilities, or dependency issues with Pillow/Authlib.