### PR TITLE
Lower WEBHOOK_TASK_TIMEOUT max to 120s; warn on in-memory fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -1175,7 +1175,7 @@ def run_configured_task(payload: dict[str, object]) -> tuple[dict[str, object], 
         return {"error": "configured task produced an empty command"}, 500
 
     try:
-        timeout = max(1, min(600, int(os.environ.get("WEBHOOK_TASK_TIMEOUT", "30"))))
+        timeout = max(1, min(120, int(os.environ.get("WEBHOOK_TASK_TIMEOUT", "30"))))
     except ValueError:
         timeout = 30
 

--- a/security.py
+++ b/security.py
@@ -144,6 +144,10 @@ def _build_primary_limiter() -> RedisRateLimiter | InMemoryRateLimiter:
     redis_prefix = os.environ.get("RATE_LIMIT_PREFIX", "miso-gallery:ratelimit")
 
     if not redis_url:
+        logger.warning(
+            "No REDIS_URL or RATE_LIMIT_REDIS_URL configured; "
+            "using in-memory rate limiter (not safe for multi-worker deployments)"
+        )
         return FALLBACK_LIMITER
 
     try:


### PR DESCRIPTION
Fixes #184

- Cap WEBHOOK_TASK_TIMEOUT env var at 120s (was 600s)
- Log warning when no Redis URL configured and using in-memory rate limiter