### PR TITLE
fix: restrict /images and /view to media files only

### DIFF
--- a/app.py
+++ b/app.py
@@ -1295,6 +1295,9 @@ def service_worker():
 @app.route("/images/<path:filename>")
 def images(filename: str):
     rel_path = sanitize_rel_path(filename)
+    media_path = source_file_path(rel_path)
+    if not media_path.exists() or not is_media_file(media_path) or is_excluded_gallery_path(media_path):
+        return "Not found", 404
     return send_from_directory(str(DATA_FOLDER), rel_path)
 
 
@@ -1446,6 +1449,9 @@ def thumb(filename: str):
 @app.route("/view/<path:filename>")
 def view(filename: str):
     rel_path = sanitize_rel_path(filename)
+    media_path = source_file_path(rel_path)
+    if not media_path.exists() or not is_media_file(media_path) or is_excluded_gallery_path(media_path):
+        return "Not found", 404
     return send_from_directory(str(DATA_FOLDER), rel_path)
 
 


### PR DESCRIPTION
Fixes #194

Restrict public direct-file routes (/images/ and /view/) to media files only.

Both routes previously served any file under DATA_FOLDER without checking
whether the file is a recognized media type or whether it resides in an
excluded path (e.g., .trash, thumbnail cache). This could expose sidecar
text/JSON files or other non-media content.

Changes:
- Added is_media_file() check to both /images/<path> and /view/<path> routes
- Added is_excluded_gallery_path() check to block access to hidden/excluded directories
- Returns 404 for non-media or excluded paths, matching the pattern used in other routes like /api/llm/image/
