### PR TITLE
ci: update pr-reviewer-action from v1.0.18 to v1.1.1

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Review PR with reusable AI reviewer
         if: github.event_name == 'pull_request'
         id: review
-        uses: misospace/pr-reviewer-action@f838c5b49d72d11dd33cfee6e29b85a28b5aa8df # v1.0.18
+        uses: misospace/pr-reviewer-action@8f72b519d2aaa4824673f5f4cbaafb7aba299349 # v1.1.1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "8"


### PR DESCRIPTION
Bump the AI PR review action from `v1.0.18` to `v1.1.1`.

This brings in:
- Cleanup of superseded native PR reviews (dismisses stale old reviews on re-review)
- CI status check before reviewing (optional)
- Review scope mode (incremental/full)
- Review markdown sanitizer
- Standards file always preserved in full on large diffs
- Glob expansion for `standards_file_candidates`
- Tool harness enforcement and timeout fixes
- Enrichment budget guardrails

See [v1.1.0 release notes](https://github.com/misospace/pr-reviewer-action/releases/tag/v1.1.0) for full details.

After this merges, Renovate will auto-update the pin digest on its next cycle.