### PR TITLE
feat(auth): add OIDC authorization controls and per-key audit logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ from flask import (
 from PIL import Image, UnidentifiedImageError
 
 from auth import (
+    _find_matching_key,
     configure_oauth,
     get_oidc_label,
     is_auth_enabled,
@@ -34,7 +35,8 @@ from auth import (
     require_auth,
     resolved_auth_mode,
     verify_local_password,
-)
+) 
+from auth import verify_oidc_authorization
 from health import health, storage_health, storage_health_read, storage_health_write
 from security import (
     add_security_headers,
@@ -111,6 +113,7 @@ def log_security_event(event: str, outcome: str, *, request_id: str = "", **fiel
             "user_id": session.get("user_id"),
             "user_name": session.get("user_name"),
             "auth_method": session.get("auth_method") or ("local" if session.get("authenticated") else None),
+            "api_key_hint": session.get("api_key_hint"),
             "request_id": request_id,
         }
         payload.update(fields)
@@ -1701,6 +1704,7 @@ def login():
     error_map = {
         "invalid": "Invalid password. Please try again.",
         "oidc_failed": "OIDC login failed. Please try again.",
+        "oidc_denied": "Your account does not meet the OIDC authorization requirements.",
         "oidc_disabled": "OIDC is not configured.",
         "local_disabled": "Password login is disabled.",
     }
@@ -2052,12 +2056,25 @@ def oidc_callback():
             resp = oauth.oidc.get("userinfo")
             user_info = resp.json()
 
+        # Extract stable subject ID (always log this for audit trails)
+        oidc_sub = user_info.get("sub")
+
         # Extract user identifier (prefer email, fallback to sub)
         user_id = user_info.get("email") or user_info.get("sub")
         user_name = user_info.get("name") or user_info.get("preferred_username") or user_id
 
         if not user_id:
             return "Could not identify user from OIDC response", 400
+
+        # Check OIDC authorization (domain/group/claim allowlists)
+        allowed, reason = verify_oidc_authorization(user_info)
+        if not allowed:
+            log_security_event(
+                "login", "denied", auth_method="oidc", reason=reason,
+                oidc_sub=oidc_sub,
+            )
+            next_url = session.pop("oidc_next_url", None) or "/"
+            return redirect(url_for("login", error="oidc_denied", next=next_url))
 
         # Set session as permanent and authenticated
         session.permanent = True
@@ -2066,7 +2083,7 @@ def oidc_callback():
         session["user_name"] = user_name
         session["auth_method"] = "oidc"
 
-        log_security_event("login", "success", auth_method="oidc")
+        log_security_event("login", "success", auth_method="oidc", oidc_sub=oidc_sub)
 
         # Redirect to the stored next URL or index
         next_url = session.pop("oidc_next_url", None) or url_for("index")

--- a/app.py
+++ b/app.py
@@ -34,8 +34,8 @@ from auth import (
     require_auth,
     resolved_auth_mode,
     verify_local_password,
-) 
-from auth import verify_oidc_authorization
+    verify_oidc_authorization,
+)
 from health import health, storage_health, storage_health_read, storage_health_write
 from security import (
     add_security_headers,

--- a/app.py
+++ b/app.py
@@ -25,7 +25,6 @@ from flask import (
 from PIL import Image, UnidentifiedImageError
 
 from auth import (
-    _find_matching_key,
     configure_oauth,
     get_oidc_label,
     is_auth_enabled,

--- a/auth.py
+++ b/auth.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import logging
-
 import json
+import logging
 import os
 import secrets
 from functools import wraps

--- a/auth.py
+++ b/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import secrets
 from functools import wraps
@@ -20,6 +21,21 @@ LLM_WRITE_API_KEYS = [key.strip() for key in os.environ.get("LLM_WRITE_API_KEYS"
 
 # Legacy single var — use LLM_READ_API_KEYS / LLM_WRITE_API_KEYS instead
 _LLM_LEGACY_KEYS = [key.strip() for key in os.environ.get("LLM_API_KEYS", "").split(",") if key.strip()]
+
+# OIDC Authorization Configuration
+OIDC_ALLOWED_DOMAINS = [
+    d.strip().lower() for d in os.environ.get("OIDC_ALLOWED_DOMAINS", "").split(",") if d.strip()
+]
+OIDC_ALLOWED_GROUPS = [
+    g.strip().lower() for g in os.environ.get("OIDC_ALLOWED_GROUPS", "").split(",") if g.strip()
+]
+OIDC_REQUIRED_CLAIMS: dict[str, str] = {}
+_oidc_required_claims_raw = os.environ.get("OIDC_REQUIRED_CLAIMS", "").strip()
+if _oidc_required_claims_raw:
+    try:
+        OIDC_REQUIRED_CLAIMS = json.loads(_oidc_required_claims_raw)
+    except (json.JSONDecodeError, ValueError):
+        OIDC_REQUIRED_CLAIMS = {}
 
 # OIDC Configuration
 OIDC_ENABLED = os.environ.get("OIDC_ENABLED", "").strip().lower() == "true"
@@ -119,6 +135,39 @@ def verify_api_key_scope(token: str, scope: Literal["read", "write"]) -> bool:
     return any(secrets.compare_digest(token, configured) for configured in keys)
 
 
+# API key identification helpers for audit logging.
+
+_API_KEY_HINT_CHARS = 4  # show first/last N chars as a stable hint
+
+
+def _api_key_hint(key: str) -> str:
+    """Return a short stable hint derived from an API key for audit logging.
+
+    Shows first 4 and last 4 characters (or less if the key is shorter).
+    Does NOT reveal the full key.
+    """
+    if not key or len(key) < 8:
+        return key[:2] + "..." if key else ""
+    return f"{key[:_API_KEY_HINT_CHARS]}...{key[-_API_KEY_HINT_CHARS:]}"
+
+
+def _find_matching_key(
+    token: str, scope: Literal["read", "write"]
+) -> tuple[bool, str | None]:
+    """Verify a bearer token and return (success, key_hint_or_none).
+
+    Uses constant-time comparison to prevent timing attacks.
+    Returns the hint for the first matching key found.
+    """
+    keys = _keys_for_scope(scope)
+    if not token or not keys:
+        return False, None
+    for configured in keys:
+        if secrets.compare_digest(token, configured):
+            return True, _api_key_hint(configured)
+    return False, None
+
+
 # Backward-compat: verify_api_key checks read scope
 def verify_api_key(token: str) -> bool:
     return verify_api_key_scope(token, "read")
@@ -172,7 +221,10 @@ def require_api_key_with_scope(scope: Literal["read", "write"]):
     def decorator(view_fn):
         @wraps(view_fn)
         def wrapper(*args, **kwargs):
-            if verify_api_key_scope(_bearer_token(), scope):
+            # Verify API key and store hint in session for audit logging
+            matched, key_hint = _find_matching_key(_bearer_token(), scope)
+            if matched:
+                session["api_key_hint"] = key_hint
                 return view_fn(*args, **kwargs)
             if is_authenticated():
                 return jsonify({"error": "Browser sessions are not accepted on LLM API endpoints"}), 403
@@ -184,6 +236,52 @@ def require_api_key_with_scope(scope: Literal["read", "write"]):
 
         return wrapper
     return decorator
+
+
+def verify_oidc_authorization(user_info: dict) -> tuple[bool, str | None]:
+    """Check OIDC user info against authorization allowlists/claims.
+
+    Returns (allowed, reason). If allowed is False, reason explains why.
+    All checks are optional — if no authorization config is set, all users pass.
+
+    Checks performed (all must pass):
+      1. Domain allowlist: if OIDC_ALLOWED_DOMAINS is set, email domain must match
+      2. Group allowlist: if OIDC_ALLOWED_GROUPS is set, user groups must intersect
+      3. Required claims: if OIDC_REQUIRED_CLAIMS is set, all key=value pairs must match
+    """
+    # Check domain allowlist
+    if OIDC_ALLOWED_DOMAINS:
+        email = (user_info.get("email") or "").lower()
+        if not email:
+            return False, "OIDC authorization failed: no email in user info"
+        user_domain = email.rsplit("@", 1)[-1] if "@" in email else ""
+        if user_domain not in OIDC_ALLOWED_DOMAINS:
+            return (
+                False,
+                f"OIDC authorization failed: domain '{user_domain}' not in allowed domains",
+            )
+
+    # Check group allowlist
+    if OIDC_ALLOWED_GROUPS:
+        groups = [g.lower() for g in user_info.get("groups", [])]
+        if not any(g in OIDC_ALLOWED_GROUPS for g in groups):
+            return (
+                False,
+                f"OIDC authorization failed: no matching group in {OIDC_ALLOWED_GROUPS}",
+            )
+
+    # Check required claims
+    if OIDC_REQUIRED_CLAIMS:
+        for claim_key, expected_value in OIDC_REQUIRED_CLAIMS.items():
+            actual = str(user_info.get(claim_key, ""))
+            if actual != expected_value:
+                return (
+                    False,
+                    f"OIDC authorization failed: claim '{claim_key}' mismatch "
+                    f"(expected '{expected_value}', got '{actual}')",
+                )
+
+    return True, None
 
 
 def get_oidc_label() -> str:

--- a/auth.py
+++ b/auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import json
 import os
 import secrets
@@ -11,6 +13,8 @@ from typing import Literal
 from authlib.integrations.flask_client import OAuth
 from flask import jsonify, redirect, request, session, url_for
 from werkzeug.security import check_password_hash
+
+logger = logging.getLogger(__name__)
 
 AuthMode = Literal["none", "local", "oidc"]
 
@@ -34,7 +38,11 @@ _oidc_required_claims_raw = os.environ.get("OIDC_REQUIRED_CLAIMS", "").strip()
 if _oidc_required_claims_raw:
     try:
         OIDC_REQUIRED_CLAIMS = json.loads(_oidc_required_claims_raw)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.warning(
+            "OIDC_REQUIRED_CLAIMS has invalid JSON (%s); authorization claim checks will be disabled",
+            exc,
+        )
         OIDC_REQUIRED_CLAIMS = {}
 
 # OIDC Configuration

--- a/tests/test_auth_matrix.py
+++ b/tests/test_auth_matrix.py
@@ -1,4 +1,3 @@
-import importlib
 import re
 import sys
 from pathlib import Path

--- a/tests/test_auth_matrix.py
+++ b/tests/test_auth_matrix.py
@@ -1,6 +1,13 @@
+import importlib
 import re
+import sys
+from pathlib import Path
 
 from conftest import build_client
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 
 def _extract_csrf(html: str) -> str:
@@ -149,3 +156,229 @@ def test_bulk_toolbar_buttons_reflect_selection_state(monkeypatch, tmp_path):
     assert "if (selectAllBtn) { selectAllBtn.disabled = totalCount === 0 || selectedCount === totalCount; }" in body
     assert "if (deselectAllBtn) { deselectAllBtn.disabled = selectedCount === 0; }" in body
     assert ".toolbar button:disabled { opacity:0.5; cursor:not-allowed; }" in body
+
+
+# ---------------------------------------------------------------------------
+# verify_oidc_authorization tests
+# ---------------------------------------------------------------------------
+
+def _reload_auth(monkeypatch, extra_env: dict | None = None):
+    """Force-reload the auth module so env var changes take effect."""
+    if extra_env:
+        for k, v in extra_env.items():
+            monkeypatch.setenv(k, str(v))
+    sys.modules.pop("auth", None)
+    import auth  # noqa: F401
+
+
+def _user_info(email="alice@example.com", groups=None, claims=None):
+    """Build a minimal OIDC user_info dict."""
+    info: dict = {"email": email}
+    if groups is not None:
+        info["groups"] = groups
+    if claims:
+        info.update(claims)
+    return info
+
+
+def test_oidc_auth_no_config_allows_all(monkeypatch, tmp_path):
+    """With no authorization config set, all users pass."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "",
+        "OIDC_ALLOWED_GROUPS": "",
+        "OIDC_REQUIRED_CLAIMS": "",
+    })
+    import auth
+    allowed, reason = auth.verify_oidc_authorization(_user_info())
+    assert allowed is True
+    assert reason is None
+
+
+def test_oidc_auth_domain_allowlist_pass(monkeypatch, tmp_path):
+    """User email domain matches the allowlist → allowed."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "example.com,corp.io",
+        "OIDC_ALLOWED_GROUPS": "",
+        "OIDC_REQUIRED_CLAIMS": "",
+    })
+    import auth
+    allowed, reason = auth.verify_oidc_authorization(_user_info(email="alice@example.com"))
+    assert allowed is True
+    assert reason is None
+
+    # Case-insensitive domain check
+    allowed2, _ = auth.verify_oidc_authorization(_user_info(email="BOB@EXAMPLE.COM"))
+    assert allowed2 is True
+
+
+def test_oidc_auth_domain_allowlist_fail(monkeypatch, tmp_path):
+    """User email domain NOT in allowlist → denied."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "example.com",
+        "OIDC_ALLOWED_GROUPS": "",
+        "OIDC_REQUIRED_CLAIMS": "",
+    })
+    import auth
+    allowed, reason = auth.verify_oidc_authorization(_user_info(email="bob@evil.com"))
+    assert allowed is False
+    assert "domain 'evil.com' not in allowed domains" in reason
+
+
+def test_oidc_auth_domain_allowlist_no_email(monkeypatch, tmp_path):
+    """User has no email → denied."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "example.com",
+        "OIDC_ALLOWED_GROUPS": "",
+        "OIDC_REQUIRED_CLAIMS": "",
+    })
+    import auth
+    allowed, reason = auth.verify_oidc_authorization({"sub": "abc123"})
+    assert allowed is False
+    assert "no email in user info" in reason
+
+
+def test_oidc_auth_group_allowlist_pass(monkeypatch, tmp_path):
+    """User belongs to an allowed group → allowed."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "",
+        "OIDC_ALLOWED_GROUPS": "admins,developers",
+        "OIDC_REQUIRED_CLAIMS": "",
+    })
+    import auth
+    allowed, reason = auth.verify_oidc_authorization(
+        _user_info(groups=["users", "developers"])
+    )
+    assert allowed is True
+    assert reason is None
+
+
+def test_oidc_auth_group_allowlist_fail(monkeypatch, tmp_path):
+    """User belongs to no allowed group → denied."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "",
+        "OIDC_ALLOWED_GROUPS": "admins,developers",
+        "OIDC_REQUIRED_CLAIMS": "",
+    })
+    import auth
+    allowed, reason = auth.verify_oidc_authorization(
+        _user_info(groups=["users", "guests"])
+    )
+    assert allowed is False
+    assert "no matching group" in reason
+
+
+def test_oidc_auth_group_allowlist_no_groups(monkeypatch, tmp_path):
+    """User has no groups field → denied."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "",
+        "OIDC_ALLOWED_GROUPS": "admins",
+        "OIDC_REQUIRED_CLAIMS": "",
+    })
+    import auth
+    allowed, reason = auth.verify_oidc_authorization(_user_info())
+    assert allowed is False
+    assert "no matching group" in reason
+
+
+def test_oidc_auth_required_claims_pass(monkeypatch, tmp_path):
+    """All required claims match → allowed."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "",
+        "OIDC_ALLOWED_GROUPS": "",
+        "OIDC_REQUIRED_CLAIMS": '{"department": "engineering", "role": "engineer"}',
+    })
+    import auth
+    allowed, reason = auth.verify_oidc_authorization(
+        _user_info(claims={"department": "engineering", "role": "engineer"})
+    )
+    assert allowed is True
+    assert reason is None
+
+
+def test_oidc_auth_required_claims_fail(monkeypatch, tmp_path):
+    """One required claim mismatch → denied."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "",
+        "OIDC_ALLOWED_GROUPS": "",
+        "OIDC_REQUIRED_CLAIMS": '{"department": "engineering"}',
+    })
+    import auth
+    allowed, reason = auth.verify_oidc_authorization(
+        _user_info(claims={"department": "marketing"})
+    )
+    assert allowed is False
+    assert "claim 'department' mismatch" in reason
+
+
+def test_oidc_auth_required_claims_missing(monkeypatch, tmp_path):
+    """Required claim not present in user info → denied."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "",
+        "OIDC_ALLOWED_GROUPS": "",
+        "OIDC_REQUIRED_CLAIMS": '{"department": "engineering"}',
+    })
+    import auth
+    allowed, reason = auth.verify_oidc_authorization(_user_info())
+    assert allowed is False
+    assert "claim 'department' mismatch" in reason
+
+
+def test_oidc_auth_combined_domain_and_group_fail_on_domain(monkeypatch, tmp_path):
+    """When both domain and group are configured, domain check runs first."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "example.com",
+        "OIDC_ALLOWED_GROUPS": "admins",
+        "OIDC_REQUIRED_CLAIMS": "",
+    })
+    import auth
+    # Wrong domain → denied even though group matches
+    allowed, reason = auth.verify_oidc_authorization(
+        _user_info(email="bob@evil.com", groups=["admins"])
+    )
+    assert allowed is False
+    assert "domain 'evil.com' not in allowed domains" in reason
+
+
+def test_oidc_auth_combined_domain_and_group_fail_on_group(monkeypatch, tmp_path):
+    """Domain passes but group fails → denied on group check."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "example.com",
+        "OIDC_ALLOWED_GROUPS": "admins",
+        "OIDC_REQUIRED_CLAIMS": "",
+    })
+    import auth
+    allowed, reason = auth.verify_oidc_authorization(
+        _user_info(email="alice@example.com", groups=["users"])
+    )
+    assert allowed is False
+    assert "no matching group" in reason
+
+
+def test_oidc_auth_malformed_json_warns(monkeypatch, tmp_path, caplog):
+    """Malformed OIDC_REQUIRED_CLAIMS JSON logs a warning instead of crashing."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "",
+        "OIDC_ALLOWED_GROUPS": "",
+        "OIDC_REQUIRED_CLAIMS": "{not valid json!!!",
+    })
+    # Re-import auth to trigger the parsing path
+    sys.modules.pop("auth", None)
+    import auth  # noqa: F401
+
+    assert auth.OIDC_REQUIRED_CLAIMS == {}
+    assert any("OIDC_REQUIRED_CLAIMS has invalid JSON" in r.message for r in caplog.records)
+
+
+def test_oidc_auth_malformed_json_allows_all(monkeypatch, tmp_path):
+    """When OIDC_REQUIRED_CLAIMS is malformed, it defaults to {} and all users pass."""
+    _reload_auth(monkeypatch, extra_env={
+        "OIDC_ALLOWED_DOMAINS": "",
+        "OIDC_ALLOWED_GROUPS": "",
+        "OIDC_REQUIRED_CLAIMS": "{{{{",
+    })
+    sys.modules.pop("auth", None)
+    import auth  # noqa: F401
+
+    allowed, reason = auth.verify_oidc_authorization(_user_info())
+    assert allowed is True
+    assert reason is None


### PR DESCRIPTION
Fixes #200

## Changes

### OIDC Authorization Controls (Issue #200)
- **OIDC_ALLOWED_DOMAINS**: Comma-separated list of allowed email domains. When set, only users whose email domain matches an entry in the allowlist can authenticate via OIDC.
- **OIDC_ALLOWED_GROUPS**: Comma-separated list of allowed OIDC groups. When set, users must belong to at least one group in the allowlist.
- **OIDC_REQUIRED_CLAIMS**: JSON object of required claim key=value pairs (e.g. ). All specified claims must match for authentication to succeed.
- Authorization failures redirect to login with a clear error message and log the denial event with the stable OIDC subject ID.

### Stable Subject ID Logging
- The OIDC  (subject) claim is now always logged in security events, regardless of email changes. This provides a stable identifier for audit trails even when user emails change.

### Per-Key API Audit Logging
- **_api_key_hint()**: Generates a short stable hint from an API key (first 4 + last 4 characters) for identification without exposing the full key.
- **_find_matching_key()**: Verifies a bearer token and returns which key matched, using constant-time comparison.
- Updated  decorator to store the matching key hint in session.
- Updated  to include  from session in all audit log entries.

## Configuration Examples

