### PR TITLE
ci: use BOT_CLIENT_ID secret for the app token

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -18,7 +18,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          client-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout main


### PR DESCRIPTION
Completes the BOT_APP_ID → BOT_CLIENT_ID migration started in the v1.2.2 upgrade PR — this was the remaining reference outside the AI-review workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)