### PR TITLE
fix: align release workflow naming, action pins, and AGENTS.md

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Generate bot token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 ---
-name: Build
+name: Release
 on:
   release:
     types:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Identity
 
-Default agent for `misospace/miso-gallery`. Role: Senior Software Engineer specializing in Python backend services and Flutter/FlutterFlow mobile applications.
+Default agent for `misospace/miso-gallery`. Role: Senior Software Engineer specializing in Python backend services with server-rendered HTML/CSS/JS frontend.
 
 ## Approval Authority
 
@@ -30,12 +30,12 @@ Default agent for `misospace/miso-gallery`. Role: Senior Software Engineer speci
 ## Repo-Specific Context
 
 ### Key Technologies
-- **Backend**: Python (FastAPI) with `app.py` as main entry point
+- **Backend**: Python (Flask) with `app.py` as main entry point
 - **Auth**: `auth.py` handles authentication
 - **Health**: `health.py` provides health check endpoints
 - **Security**: `security.py` contains security utilities
-- **Frontend**: Flutter/FlutterFlow (in `assets/` directory)
-- **Database**: SQLite likely (standard for gallery apps)
+- **Frontend**: Server-rendered HTML/CSS/JS via `render_template_string` in `app.py`
+- **Database**: None — the application is stateless; images are stored on disk
 
 ### Version Management
 - In-app version is sourced from `app.py`
@@ -86,7 +86,7 @@ git push origin <version>
 gh release create <version> --repo misospace/miso-gallery --title "<version>" --generate-notes
 ```
 
-The tag push also triggers the `Build` workflow (`.github/workflows/release.yaml`): multi-arch Docker image build + push to GHCR.
+The tag push also triggers the `Release` workflow (`.github/workflows/release.yaml`): multi-arch Docker image build + push to GHCR.
 
 #### Version source of truth
 


### PR DESCRIPTION
Fixes #204

- Rename duplicate 'Build' workflow name in release.yaml to 'Release'
- Align actions/create-github-app-token to v3.2.0 in manual-release.yml (matching ai-pr-review.yaml)
- Update AGENTS.md to match actual architecture: Flask (not FastAPI), server-rendered HTML/CSS/JS (not Flutter), no database (not SQLite)