### PR TITLE
Add destructive-operation guardrails (#199)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1531,7 +1531,6 @@ def bulk_delete():
             # sanitize_path() rejects paths containing ".." or starting with "/" (security.py:sanitize_path)
             # sanitize_rel_path() further normalizes and double-checks (app.py:sanitize_rel_path)
 
-
             continue
         safe_rel_path = sanitize_rel_path(rel_path)
         folder_path = DATA_FOLDER / safe_rel_path

--- a/trash.py
+++ b/trash.py
@@ -10,6 +10,21 @@ from pathlib import Path
 TRASH_DIR_NAME = ".trash"
 META_SUFFIX = ".meta.json"
 
+def dir_size(path: Path) -> int:
+    """Estimate total size of a directory tree in bytes."""
+    total = 0
+    try:
+        for entry in path.rglob('*'):
+            if entry.is_file():
+                try:
+                    total += entry.stat().st_size
+                except OSError:
+                    pass
+    except OSError:
+        pass
+    return total
+
+
 
 def dir_size(path: Path) -> int:
     """Estimate total size of a directory tree in bytes.

--- a/trash.py
+++ b/trash.py
@@ -10,16 +10,21 @@ from pathlib import Path
 TRASH_DIR_NAME = ".trash"
 META_SUFFIX = ".meta.json"
 
+
 def dir_size(path: Path) -> int:
-    """Estimate total size of a directory tree in bytes."""
+    """Estimate total size of a directory tree in bytes.
+
+    Skips symlinks to prevent information disclosure and DoS via symlink
+    cycles or external filesystem traversal.
+    """
     total = 0
     try:
-        for entry in path.rglob('*'):
+        for entry in path.rglob("*"):
+            if entry.is_symlink():
+                continue
             if entry.is_file():
-                try:
+                with contextlib.suppress(OSError):
                     total += entry.stat().st_size
-                except OSError:
-                    pass
     except OSError:
         pass
     return total

--- a/trash.py
+++ b/trash.py
@@ -25,6 +25,8 @@ def dir_size(path: Path) -> int:
             if entry.is_file():
                 with contextlib.suppress(OSError):
                     total += entry.stat().st_size
+                # Intentionally suppress OSError (e.g., permission denied) for
+                # individual files during size estimation; we only need an estimate.
     except OSError:
         pass
     return total

--- a/trash.py
+++ b/trash.py
@@ -30,30 +30,6 @@ def dir_size(path: Path) -> int:
     except OSError:
         pass
     return total
-
-
-
-def dir_size(path: Path) -> int:
-    """Estimate total size of a directory tree in bytes.
-
-    Skips symlinks to prevent information disclosure and DoS via symlink
-    cycles or external filesystem traversal.
-    """
-    total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_symlink():
-                continue
-            if entry.is_file():
-                with contextlib.suppress(OSError):
-                    total += entry.stat().st_size
-                # Intentionally suppress OSError (e.g., permission denied) for
-                # individual files during size estimation; we only need an estimate.
-    except OSError:
-        pass
-    return total
-
-
 def trash_dir(data_folder: Path) -> Path:
     path = data_folder / TRASH_DIR_NAME
     path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes #199

## Summary

Adds per-request caps and preflight size estimation for all destructive operations in miso-gallery.

### Changes

**app.py:**
- Added configurable constants (env-var overridable):
  - BULK_DELETE_MAX_ITEMS (default: 200) — total file+folder items in bulk delete
  - BULK_DELETE_MAX_FOLDERS (default: 50) — folder count cap in bulk delete
  - BULK_DELETE_FOLDER_SIZE_CAP (default: 10 GB) — preflight size limit for folders
  - LLM_BULK_DELETE_MAX_ITEMS (default: 500) — max rel_paths in LLM bulk delete
  - LLM_DEDUP_MAX_REMOVALS (default: 200) — max duplicates removed in dedup
- bulk_delete: validates item count, folder count, and preflights folder sizes before proceeding
- llm_bulk_delete: validates rel_paths count before processing
- llm_dedup: estimates total removals and rejects if exceeding cap
- All rejections return HTTP 422 with descriptive error messages
- Rejected requests logged via log_security_event for audit trail

**trash.py:**
- Added dir_size(path) helper to estimate directory tree size by summing file sizes