### PR TITLE
ci: bump tool_planning_max_tokens 300 → 1500

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -60,7 +60,7 @@ jobs:
           tool_max_requests: "4"
           tool_planning_timeout_sec: "45"
           tool_planning_max_context_bytes: "15000"
-          tool_planning_max_tokens: "300"
+          tool_planning_max_tokens: "1500"
           tool_max_response_bytes: "12000"
           tool_allowed_gh_api_repos: "*"
           tool_request_timeout_sec: "15"


### PR DESCRIPTION
Raises the pr-reviewer-action tool-harness planning budget from 300 tokens (below the action's own 400 default) to 1500, matching the home-ops change.

With 300 tokens the planning call to the local `review` model frequently failed (truncated/empty plan), so reviews ran with no tool evidence — and before [pr-reviewer-action v1.2.5](https://github.com/misospace/pr-reviewer-action/releases/tag/v1.2.5) each failure also escalated the review to the smart model. v1.2.5 stops the escalation; this gets the harness actually producing evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)