### PR TITLE
chore: bump APP_VERSION from 0.1.17 to 0.1.18

### DIFF
--- a/app.py
+++ b/app.py
@@ -140,7 +140,7 @@ FAVICON_URL = os.environ.get("FAVICON_URL", "").strip()
 
 PWA_THEME_COLOR = "#0d0d0d"
 PWA_APP_NAME = "Miso Gallery"
-APP_VERSION = (os.environ.get("APP_VERSION") or "0.1.17").strip() or "0.1.17"
+APP_VERSION = (os.environ.get("APP_VERSION") or "0.1.18").strip() or "0.1.18"
 WEBHOOK_TASK_PREFIX = "WEBHOOK_TASK_"
 AUTO_FOLDER_COVERS_ENABLED = os.environ.get("GALLERY_AUTO_FOLDER_COVERS", "false").strip().lower() in {"1", "true", "yes", "on"}
 FOLDER_COVER_CACHE_TTL = max(int(os.environ.get("GALLERY_COVER_CACHE_TTL", "3600") or 3600), 0)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -59,7 +59,7 @@ GET /health
 ```json
 {
   "status": "healthy",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "timestamp": "2026-05-18T09:00:00+00:00",
   "storage": {
     "status": "healthy",
@@ -314,7 +314,7 @@ Tasks can also be disabled per-task by unsetting the `WEBHOOK_TASK_*` variable.
 
 1. Bump `APP_VERSION` in `app.py` (line 133):
    ```python
-   APP_VERSION = (os.environ.get("APP_VERSION") or "0.1.17").strip() or "0.1.17"
+   APP_VERSION = (os.environ.get("APP_VERSION") or "0.1.18").strip() or "0.1.18"
    ```
 
 2. Run the Manual Release workflow from the GitHub Actions tab, or tag and push:


### PR DESCRIPTION
Bump in-app version for the next release.

### Highlights since v0.1.17
- OIDC authorization controls + per-key audit logging (#212)
- API key class in audit events (#221)
- Bounded recursive scans + central iterator; dir trash fix (#222)
- `/health` read-only split + write-probe endpoint (GH #197 / #216)
- Inline templates extracted from `app.py` (#224)
- Release workflow naming + action pins aligned (#204)
- Security edge regression tests (#223)
- Label-driven AI re-review + `/ai-review` comment (#226, #227)
- pr-reviewer-action upgrades (v1.2.x → v1.3.0, #230)

### Validation (CI on this PR)
- lint: pending
- test: pending
- audit: pending