### PR TITLE
fix(ci): route manual-release through PR + auto-merge

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Generate bot token
         id: app-token
@@ -62,14 +63,51 @@ jobs:
           path.write_text(updated)
           PY
 
-      - name: Commit version bump
+      - name: Commit version bump to release branch
+        id: bump
         run: |
           git add app.py
           if git diff --cached --quiet; then
             echo "No version file changes to commit"
           else
-            git commit -m "chore(release): bump version to ${{ steps.version.outputs.version }}"
-            git push origin HEAD:main
+            BRANCH="chore/bump-version-${{ steps.version.outputs.version }}"
+            git commit -m "chore(release): bump APP_VERSION to ${{ steps.version.outputs.version }}"
+            git push origin "HEAD:${BRANCH}"
+            echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open version-bump PR and enable auto-merge
+        if: steps.bump.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "chore: bump APP_VERSION to ${VERSION}" \
+            --body "Automated in-app version bump to ${VERSION} for the next release." \
+            --delete-branch
+          gh pr merge "${BRANCH}" --auto --squash --delete-branch
+
+      - name: Wait for version-bump PR to merge
+        if: steps.bump.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
+        run: |
+          for i in $(seq 1 120); do
+            STATE=$(gh pr view "${BRANCH}" --json state -q .state 2>/dev/null || echo "OPEN")
+            if [ "$STATE" = "MERGED" ]; then
+              echo "PR merged"
+              break
+            fi
+            sleep 5
+          done
+          if [ "$STATE" != "MERGED" ]; then
+            echo "ERROR: version-bump PR did not merge within 10 minutes"
+            exit 1
           fi
 
       - name: Ensure remote main is current


### PR DESCRIPTION
## Problem

The in-repo **Manual Release** workflow has been silently broken since main became protected. The `Commit version bump` step did `git push origin HEAD:main` directly, which GitHub now rejects:

> GH006: Protected branch update failed for refs/heads/main.
> - Changes must be made through a pull request.
> - 6 of 6 required status checks are expected.

This means triggering the workflow produces a version-bump commit that never reaches main, and the rest of the job (tag + release) hangs on a stale local checkout.

## Fix

Replace the direct-to-main push with the same path the team has been using manually for past releases (e.g. #177, #231):

1. Push the version-bump commit to a release branch (`chore/bump-version-<version>`).
2. Open a PR against `main`.
3. Enable squash auto-merge via `gh pr merge --auto --squash --delete-branch`.
4. Poll until the PR is MERGED.
5. Fetch main, create the tag, create the GitHub release — same as before.

Added `pull-requests: write` to job permissions so `gh pr create` / `gh pr merge` work with the bot app token.

## Notes

- The release artifact (tag, release notes, `APP_VERSION` bump) is unchanged.
- The PR title matches the past pattern (`chore: bump APP_VERSION to <version>`).
- Timeout is 10 minutes for the auto-merge wait; if it doesn't merge in time, the workflow fails loudly with the branch name so the release can be retried or finished manually.
- The follow-up failure on the 0.1.18 manual-release workflow run was this same bug — that release was finished manually via PR #231.