### PR TITLE
fix(release): automate protected releases

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -4,12 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g. 0.4.6 or v0.4.6; will normalize to 0.4.6)'
+        description: 'Release version (for example 0.1.19 or v0.1.19)'
         required: true
         type: string
 
+concurrency:
+  group: manual-release
+  cancel-in-progress: false
+
 jobs:
-  release:
+  prepare-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -29,111 +33,72 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Normalize version
+      - name: Normalize and validate version
         id: version
+        env:
+          RAW_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          RAW='${{ github.event.inputs.version }}'
-          VERSION="${RAW#v}"
+          VERSION="${RAW_VERSION#v}"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Invalid version: $RAW"
+            echo "Invalid version: $RAW_VERSION"
+            exit 1
+          fi
+          if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists"
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Configure git
-        run: |
-          git config user.name "smurf-bot[bot]"
-          git config user.email "smurf-bot[bot]@users.noreply.github.com"
-
-      - name: Ensure app version constant matches release
+      - name: Update app version
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           python3 - <<'PY'
           from pathlib import Path
-          import os, re
-          version = os.environ['VERSION']
-          path = Path('app.py')
+          import os
+          import re
+
+          version = os.environ["VERSION"]
+          path = Path("app.py")
           text = path.read_text()
-          updated, count = re.subn(r'APP_VERSION = \(os\.environ\.get\("APP_VERSION"\) or ".*?"\)\.strip\(\) or ".*?"', f'APP_VERSION = (os.environ.get("APP_VERSION") or "{version}").strip() or "{version}"', text, count=1)
+          replacement = f'APP_VERSION = (os.environ.get("APP_VERSION") or "{version}").strip() or "{version}"'
+          updated, count = re.subn(
+              r'APP_VERSION = \(os\.environ\.get\("APP_VERSION"\) or ".*?"\)\.strip\(\) or ".*?"',
+              replacement,
+              text,
+              count=1,
+          )
           if count != 1:
-              raise SystemExit('Failed to update APP_VERSION in app.py')
+              raise SystemExit("Failed to update APP_VERSION in app.py")
           path.write_text(updated)
           PY
 
-      - name: Commit version bump to release branch
-        id: bump
-        run: |
-          git add app.py
-          if git diff --cached --quiet; then
-            echo "No version file changes to commit"
-          else
-            BRANCH="chore/bump-version-${{ steps.version.outputs.version }}"
-            git commit -m "chore(release): bump APP_VERSION to ${{ steps.version.outputs.version }}"
-            git push origin "HEAD:${BRANCH}"
-            echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Open version-bump PR and enable auto-merge
-        if: steps.bump.outputs.branch != ''
+      - name: Commit and push release branch
+        id: branch
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          BRANCH: ${{ steps.bump.outputs.branch }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          gh pr create \
-            --base main \
-            --head "${BRANCH}" \
-            --title "chore: bump APP_VERSION to ${VERSION}" \
-            --body "Automated in-app version bump to ${VERSION} for the next release." \
-            --delete-branch
-          gh pr merge "${BRANCH}" --auto --squash --delete-branch
+          set -euo pipefail
+          BRANCH="chore/release-v${VERSION}-${GITHUB_RUN_ID}"
+          git config user.name "smurf-bot[bot]"
+          git config user.email "smurf-bot[bot]@users.noreply.github.com"
+          git add app.py
+          git commit -m "chore(release): bump version to ${VERSION}"
+          git push origin "HEAD:refs/heads/${BRANCH}"
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for version-bump PR to merge
-        if: steps.bump.outputs.branch != ''
+      - name: Open release PR and enable auto-merge
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          BRANCH: ${{ steps.bump.outputs.branch }}
-        run: |
-          for i in $(seq 1 120); do
-            STATE=$(gh pr view "${BRANCH}" --json state -q .state 2>/dev/null || echo "OPEN")
-            if [ "$STATE" = "MERGED" ]; then
-              echo "PR merged"
-              break
-            fi
-            sleep 5
-          done
-          if [ "$STATE" != "MERGED" ]; then
-            echo "ERROR: version-bump PR did not merge within 10 minutes"
-            exit 1
-          fi
-
-      - name: Ensure remote main is current
-        run: |
-          git fetch origin main --tags
-          git checkout main
-          git reset --hard origin/main
-
-      - name: Create tag
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists"
-            exit 1
-          fi
-          git tag "$TAG"
-          git push origin "$TAG"
-
-      - name: Create GitHub release with generated notes
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          gh release create "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "$TAG" \
-            --generate-notes
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(release): bump version to ${VERSION}" \
+            --body "Version bump for release ${VERSION}. The release will be published after this PR passes the required checks and merges.")
+          gh pr merge "$PR_URL" --auto --squash --delete-branch
+          echo "Release PR: $PR_URL"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,115 @@
+name: Publish Release
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      release_pr:
+        description: 'Merged release PR number to recover or republish'
+        required: true
+        type: number
+
+concurrency:
+  group: publish-release-${{ inputs.release_pr || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  publish-release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'chore/release-v') &&
+      endsWith(github.event.pull_request.user.login, '[bot]'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Generate bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
+      - name: Resolve and verify release PR
+        id: release-pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ inputs.release_pr || github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          PR=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json author,headRefName,mergedAt,mergeCommit)
+          IS_BOT=$(jq -r '.author.is_bot // false' <<<"$PR")
+          HEAD_REF=$(jq -r '.headRefName' <<<"$PR")
+          MERGED_AT=$(jq -r '.mergedAt // empty' <<<"$PR")
+          MERGE_SHA=$(jq -r '.mergeCommit.oid // empty' <<<"$PR")
+          if [ -z "$MERGED_AT" ] || [ -z "$MERGE_SHA" ] || [ "$IS_BOT" != "true" ] || [[ "$HEAD_REF" != chore/release-v* ]]; then
+            echo "PR #$PR_NUMBER is not a merged bot-authored release PR"
+            exit 1
+          fi
+          FILES=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json files --jq '.files[].path')
+          if [ "$FILES" != "app.py" ]; then
+            echo "Release PR changed unexpected files:"
+            echo "$FILES"
+            exit 1
+          fi
+          echo "merge_sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout merged release
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.release-pr.outputs.merge_sha }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Resolve release version
+        id: release
+        run: |
+          set -euo pipefail
+          VERSION=$(python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          text = Path("app.py").read_text()
+          match = re.search(r'^APP_VERSION = \(os\.environ\.get\("APP_VERSION"\) or "([^"]+)"\)\.strip\(\) or "\1"$', text, re.MULTILINE)
+          if not match:
+              raise SystemExit("APP_VERSION is missing or inconsistent")
+          print(match.group(1))
+          PY
+          )
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid APP_VERSION: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag at merge commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          MERGE_SHA: ${{ steps.release-pr.outputs.merge_sha }}
+          TAG: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          if EXISTING_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq .object.sha 2>/dev/null); then
+            if [ "$EXISTING_SHA" != "$MERGE_SHA" ]; then
+              echo "Tag $TAG already points to $EXISTING_SHA"
+              exit 1
+            fi
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$TAG" -f sha="$MERGE_SHA" >/dev/null
+          fi
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists"
+          else
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,49 +42,14 @@ Default agent for `misospace/miso-gallery`. Role: Senior Software Engineer speci
 - Release automation must keep `app.py` version aligned with release tag
 
 ### Release Process
-The release process is manual and CLI-driven. Branch protection blocks direct pushes to `main`, so all version bumps go through a branch + PR.
+Releases are started manually and completed by GitHub Actions. Branch protection remains enabled: the workflow opens an `app.py` version-bump PR and enables auto-merge instead of pushing directly to `main`.
 
 #### Steps
 
-```bash
-# Ensure main is up-to-date
-git checkout main
-git pull --ff-only --tags origin main
-
-# Branch for the version bump
-git checkout -b chore/release-v<version>
-
-# Update version in app.py (in-app version source)
-# Update APP_VERSION in the source to match the release version
-
-# Validate (Python toolchain — no Node/npm)
-python3 -m pip install -q -r requirements.txt 2>/dev/null
-python3 -m pip install -q ruff pytest requests 2>/dev/null
-ruff check . --select=E,F,W,B,SIM,I --ignore=E501 --statistics
-python3 -m pytest -q
-
-# Commit and push branch
-git add .
-git commit -m "chore(release): bump version to <version>"
-git push -u origin chore/release-v<version>
-
-# Open PR and squash-merge
-gh pr create --repo misospace/miso-gallery --base main --head chore/release-v<version> \
-  --title "chore(release): bump version to <version>" \
-  --body "Version bump for release v<version>."
-
-# Merge the PR
-gh pr merge --repo misospace/miso-gallery --squash --delete-branch
-
-# After PR merge, tag from up-to-date main
-git checkout main
-git pull --ff-only --tags origin main
-git tag <version>
-git push origin <version>
-
-# Create release
-gh release create <version> --repo misospace/miso-gallery --title "<version>" --generate-notes
-```
+1. Open **Actions → Manual Release → Run workflow**.
+2. Enter a plain semver version such as `0.1.19` (`v0.1.19` is also accepted).
+3. Follow the linked release PR. It auto-merges after the required checks pass.
+4. `Publish Release` verifies `APP_VERSION`, tags the merge commit, and creates the GitHub release.
 
 The tag push also triggers the `Release` workflow (`.github/workflows/release.yaml`): multi-arch Docker image build + push to GHCR.
 
@@ -96,9 +61,7 @@ The tag push also triggers the `Release` workflow (`.github/workflows/release.ya
 
 #### Validation gates
 
-Before opening the version bump PR:
-- `ruff check . --select=E,F,W,B,SIM,I --ignore=E501 --statistics` — lint pass
-- `python -m pytest -q` — all unit tests pass
+The release PR must pass the protected branch's required lint and test checks before auto-merge.
 
 
 ## Guidelines


### PR DESCRIPTION
Replace the broken polling release job with an event-driven `APP_VERSION` PR and merged-PR publisher. Includes the proven explicit-repository, App-author, missing-tag, and manual-recovery handling from miso-chat.

Validated with YAML parsing, an `APP_VERSION` mutation simulation, and `git diff --check`.