### PR TITLE
build(release): extract APP_VERSION via Python instead of grep

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,17 @@ jobs:
           set -euo pipefail
           TAG="${{ github.event.release.tag_name }}"
           TAG="${TAG#v}"
-          VERSION=$(grep '^APP_VERSION = ' app.py | head -1 | grep -oP 'or "\K[^"]+' | head -1)
+          VERSION=$(python3 - <<'PY'
+            import re
+            from pathlib import Path
+
+            text = Path("app.py").read_text()
+            match = re.search(r'^APP_VERSION = \(os\.environ\.get\("APP_VERSION"\) or "([^"]+)"\)\.strip\(\) or "\1"$', text, re.MULTILINE)
+            if not match:
+                raise SystemExit("APP_VERSION is missing or inconsistent")
+            print(match.group(1))
+          PY
+          )
           if [ "$VERSION" != "$TAG" ]; then
             echo "ERROR: APP_VERSION ($VERSION) does not match release tag ($TAG)"
             echo "The APP_VERSION constant in app.py must be bumped to $TAG before releasing."


### PR DESCRIPTION
## Summary
- Replaces brittle `grep -oP` chain with Python script that reads app.py and extracts APP_VERSION via regex
- Python extraction correctly handles the os.environ pattern and fails explicitly if version is missing or inconsistent

Closes #253

🤖 Branch authored autonomously by the foreman pipeline (Saffron); PR description written from the diff.
