### PR TITLE
Fix release workflow: use full SHA for pre-built image check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,10 +68,9 @@ jobs:
       - name: Check for pre-built image from CI build
         id: prebuilt
         run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
-          if docker buildx imagetools inspect "ghcr.io/${{ github.repository }}:main-${SHORT_SHA}" >/dev/null 2>&1; then
+          if docker buildx imagetools inspect "ghcr.io/${{ github.repository }}:main-${GITHUB_SHA}" >dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Pre-built image main-${SHORT_SHA} available; skipping rebuild."
+            echo "Pre-built image main-${GITHUB_SHA} available; skipping rebuild."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "No pre-built image; will build from source."
@@ -91,15 +90,14 @@ jobs:
       - name: Export digest from pre-built image
         if: steps.prebuilt.outputs.exists == 'true'
         run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
           ARCH="${{ matrix.arch }}"
           mkdir -p ${{ runner.temp }}/digests
           DIGEST=$(docker buildx imagetools inspect --raw \
-            "ghcr.io/${{ github.repository }}:main-${SHORT_SHA}" 2>/dev/null \
+            "ghcr.io/${{ github.repository }}:main-${GITHUB_SHA}" 2>/dev/null \
             | jq -r --arg arch "$ARCH" \
               '.[] | select(.Descriptor.platform.architecture == $arch) | .Descriptor.digest')
           if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
-            echo "::error::Could not locate $ARCH digest in pre-built main-${SHORT_SHA} manifest."
+            echo "::error::Could not locate $ARCH digest in pre-built main-${GITHUB_SHA} manifest."
             exit 1
           fi
           touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,8 +65,21 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
 
+      - name: Check for pre-built image from CI build
+        id: prebuilt
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          if docker buildx imagetools inspect "ghcr.io/${{ github.repository }}:main-${SHORT_SHA}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Pre-built image main-${SHORT_SHA} available; skipping rebuild."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No pre-built image; will build from source."
+          fi
+
       - name: Build and push Docker image
         id: build
+        if: steps.prebuilt.outputs.exists != 'true'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -75,7 +88,24 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
+      - name: Export digest from pre-built image
+        if: steps.prebuilt.outputs.exists == 'true'
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          ARCH="${{ matrix.arch }}"
+          mkdir -p ${{ runner.temp }}/digests
+          DIGEST=$(docker buildx imagetools inspect --raw \
+            "ghcr.io/${{ github.repository }}:main-${SHORT_SHA}" 2>/dev/null \
+            | jq -r --arg arch "$ARCH" \
+              '.[] | select(.Descriptor.platform.architecture == $arch) | .Descriptor.digest')
+          if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
+            echo "::error::Could not locate $ARCH digest in pre-built main-${SHORT_SHA} manifest."
+            exit 1
+          fi
+          touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
+
       - name: Export digest
+        if: steps.prebuilt.outputs.exists != 'true'
         run: |
           mkdir -p ${{ runner.temp }}/digests
           digest="${{ steps.build.outputs.digest }}"
@@ -122,12 +152,13 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |-
             type=semver,pattern={{version}}
+            type=raw,value=latest
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         if: github.event_name != 'pull_request'
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<<"$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
 
       - name: Inspect image


### PR DESCRIPTION
Branch correctly fixes release workflow: restores :latest tag publishing and eliminates double build via pre-built image check.

Fixes #251

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-251)._