### PR TITLE
Make rate-limit configuration lazily loaded and re-readable at runtime

### DIFF
--- a/security.py
+++ b/security.py
@@ -142,7 +142,12 @@ return 1
 
 
 FALLBACK_LIMITER = InMemoryRateLimiter()
-ROUTE_LIMIT_OVERRIDES = _load_route_overrides()
+
+# Lazy-loaded route overrides and primary limiter so that:
+# - tests can inject mock limiters without module-level patching
+# - environment changes can be picked up via refresh_route_overrides() / refresh_primary_limiter()
+_route_limit_overrides: dict[str, RateLimitConfig] | None = None
+_primary_limiter: RedisRateLimiter | InMemoryRateLimiter | None = None
 
 
 def _build_primary_limiter() -> RedisRateLimiter | InMemoryRateLimiter:
@@ -165,7 +170,34 @@ def _build_primary_limiter() -> RedisRateLimiter | InMemoryRateLimiter:
         return FALLBACK_LIMITER
 
 
-PRIMARY_LIMITER = _build_primary_limiter()
+def get_route_limit_overrides() -> dict[str, RateLimitConfig]:
+    """Return the current route limit overrides, loading lazily on first call."""
+    global _route_limit_overrides
+    if _route_limit_overrides is None:
+        _route_limit_overrides = _load_route_overrides()
+    return _route_limit_overrides
+
+
+def refresh_route_overrides() -> dict[str, RateLimitConfig]:
+    """Reload route limit overrides from the current environment."""
+    global _route_limit_overrides
+    _route_limit_overrides = _load_route_overrides()
+    return _route_limit_overrides
+
+
+def get_primary_limiter() -> RedisRateLimiter | InMemoryRateLimiter:
+    """Return the primary rate limiter, building it lazily on first call."""
+    global _primary_limiter
+    if _primary_limiter is None:
+        _primary_limiter = _build_primary_limiter()
+    return _primary_limiter
+
+
+def refresh_primary_limiter() -> RedisRateLimiter | InMemoryRateLimiter:
+    """Rebuild the primary rate limiter from the current environment."""
+    global _primary_limiter
+    _primary_limiter = _build_primary_limiter()
+    return _primary_limiter
 
 
 def _is_trusted_source(source_addr: str | None) -> bool:
@@ -253,7 +285,7 @@ def _client_ip() -> str:
 
 
 def _effective_config(endpoint: str, default_max_requests: int, default_window: int) -> RateLimitConfig:
-    override = ROUTE_LIMIT_OVERRIDES.get(endpoint)
+    override = get_route_limit_overrides().get(endpoint)
     if override:
         return override
     return RateLimitConfig(max_requests=default_max_requests, window=default_window)
@@ -273,7 +305,7 @@ def rate_limit(max_requests: int = 30, window: int = 60):
             key = f"{_client_ip()}:{endpoint}"
 
             try:
-                allowed = PRIMARY_LIMITER.allow(key, config.max_requests, config.window)
+                allowed = get_primary_limiter().allow(key, config.max_requests, config.window)
             except Exception as exc:  # pragma: no cover - runtime resilience
                 logger.warning("Primary limiter failed (%s); using in-memory fallback", exc)
                 allowed = FALLBACK_LIMITER.allow(key, config.max_requests, config.window)

--- a/tests/test_security_edges.py
+++ b/tests/test_security_edges.py
@@ -455,3 +455,60 @@ def test_load_route_overrides_blank_endpoint_key_skipped(monkeypatch):
     overrides = _load_route_overrides()
     assert "" not in overrides
     assert "auth" in overrides
+
+
+def test_get_route_limit_overrides_lazy(monkeypatch):
+    """get_route_limit_overrides loads lazily on first call."""
+    import security
+
+    monkeypatch.setenv("RATE_LIMIT_ROUTE_LIMITS", json.dumps({"test": {"max_requests": 1, "window": 10}}))
+
+    # Force a fresh load by resetting the module-level cache
+    security._route_limit_overrides = None
+
+    overrides = security.get_route_limit_overrides()
+    assert "test" in overrides
+    assert overrides["test"].max_requests == 1
+
+
+def test_refresh_route_overrides_picks_up_env_change(monkeypatch):
+    """refresh_route_overrides reloads from the current environment."""
+    import security
+
+    monkeypatch.setenv("RATE_LIMIT_ROUTE_LIMITS", json.dumps({"initial": {"max_requests": 5, "window": 60}}))
+    security._route_limit_overrides = None
+
+    overrides1 = security.get_route_limit_overrides()
+    assert "initial" in overrides1
+
+    # Change the environment variable and refresh
+    monkeypatch.setenv("RATE_LIMIT_ROUTE_LIMITS", json.dumps({"updated": {"max_requests": 10, "window": 120}}))
+    overrides2 = security.refresh_route_overrides()
+    assert "updated" in overrides2
+    assert "initial" not in overrides2
+
+
+def test_get_primary_limiter_lazy(monkeypatch):
+    """get_primary_limiter builds lazily on first call."""
+    import security
+
+    # Force a fresh build by resetting the module-level cache
+    security._primary_limiter = None
+
+    limiter = security.get_primary_limiter()
+    assert limiter is not None
+    assert hasattr(limiter, "allow")
+
+
+def test_refresh_primary_limiter_rebuilds(monkeypatch):
+    """refresh_primary_limiter rebuilds from the current environment."""
+    import security
+
+    # Force a fresh build by resetting the module-level cache
+    security._primary_limiter = None
+
+    limiter1 = security.get_primary_limiter()
+    assert limiter1 is not None
+
+    limiter2 = security.refresh_primary_limiter()
+    assert limiter2 is not None


### PR DESCRIPTION
## What
Converted `ROUTE_LIMIT_OVERRIDES` and `PRIMARY_LIMITER` in `security.py` from module-level constants (initialized at import time) to lazy-loaded globals with accessor (`get_*`) and refresh (`refresh_*`) functions. Added 4 tests covering lazy loading and refresh behavio…

Fixes #328

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-328)._