### PR TITLE
Refactor folder_cover_rel_path to use iter_gallery_items

### DIFF
--- a/app.py
+++ b/app.py
@@ -347,27 +347,15 @@ def folder_cover_rel_path(folder_rel_path: str) -> str | None:
         _FOLDER_COVER_CACHE[folder_rel_path] = (now, None)
         return None
 
-    cover_rel: str | None = None
-    # Bound the scan to prevent unbounded subtree traversal on cache misses.
-    candidates = []
-    for count, item in enumerate(folder_path.rglob("*")):
-        if count >= GALLERY_SCAN_LIMIT:
-            break
-        candidates.append(item)
-    candidates.sort(key=lambda p: p.as_posix().lower())
-    for candidate in candidates:
-        if not candidate.is_file() or candidate.suffix.lower() not in IMAGE_EXTENSIONS:
-            continue
-        rel_candidate = candidate.relative_to(DATA_FOLDER)
-        if any(part in {".thumb_cache", ".trash"} or part.startswith(".") for part in rel_candidate.parts):
-            continue
-        cover_rel = rel_candidate.as_posix()
-        break
+    # Delegate to iter_gallery_items for bounded, exclusion-aware scanning.
+    items = iter_gallery_items(kind="media", limit=1, root=folder_path)
 
-    if cover_rel is None:
+    if not items:
         _FOLDER_COVER_CACHE.pop(folder_rel_path, None)
-    else:
-        _FOLDER_COVER_CACHE[folder_rel_path] = (now, cover_rel)
+        return None
+
+    cover_rel = items[0].relative_to(DATA_FOLDER).as_posix()
+    _FOLDER_COVER_CACHE[folder_rel_path] = (now, cover_rel)
     return cover_rel
 
 
@@ -431,6 +419,7 @@ def media_metadata(path: Path, tags: list[str] | None = None) -> dict[str, objec
 def iter_gallery_items(
     kind: str = "media",
     limit: int | None = None,
+    root: Path | None = None,
 ) -> list[Path]:
     """Centralized bounded iterator for gallery filesystem scans.
 
@@ -440,13 +429,15 @@ def iter_gallery_items(
     Args:
         kind: "media" (files only), "folders" (dirs only), or "all" (both).
         limit: Maximum items to return. Defaults to GALLERY_SCAN_LIMIT.
+        root: Optional root directory to scan. Defaults to DATA_FOLDER.
 
     Returns:
         Sorted list of Path objects within the bound.
     """
     effective_limit = limit if limit is not None else GALLERY_SCAN_LIMIT
+    scan_root = root if root is not None else DATA_FOLDER
     results: list[Path] = []
-    for item in DATA_FOLDER.rglob("*"):
+    for item in scan_root.rglob("*"):
         if len(results) >= effective_limit:
             break
         try:

--- a/tests/test_bounded_scans.py
+++ b/tests/test_bounded_scans.py
@@ -201,3 +201,123 @@ class TestScanLimitConstant:
         import app as app_module
         assert hasattr(app_module, "GALLERY_SCAN_LIMIT")
         assert app_module.GALLERY_SCAN_LIMIT == 5000
+
+
+class TestFolderCoverDelegatesToIterGalleryItems:
+    """folder_cover_rel_path delegates to iter_gallery_items (issue #325)."""
+
+    def test_cover_uses_iter_gallery_items(self, monkeypatch, tmp_path):
+        """folder_cover_rel_path should use iter_gallery_items with root=folder."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / ".thumb_cache").mkdir(exist_ok=True)
+
+        # Create a subfolder with media files
+        subfolder = data_dir / "photos"
+        subfolder.mkdir()
+        (subfolder / "cover.png").write_bytes(
+            b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01'
+            b'\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde'
+        )
+        (subfolder / "other.jpg").write_bytes(
+            b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01'
+        )
+
+        monkeypatch.setenv("DATA_FOLDER", str(data_dir))
+        monkeypatch.setenv("AUTH_TYPE", "local")
+        monkeypatch.setenv("ADMIN_PASSWORD", "pass123")
+        monkeypatch.setenv("OIDC_ENABLED", "false")
+        monkeypatch.setenv("SECRET_KEY", "test-secret-ci-gateway")
+        monkeypatch.setenv("LLM_API_KEYS", "agent-key")
+        monkeypatch.setenv("GALLERY_AUTO_FOLDER_COVERS", "true")
+
+        for mod in ("auth", "app"):
+            sys.modules.pop(mod, None)
+
+        import app as app_module
+        app_module.DATA_FOLDER = data_dir
+        app_module.THUMBNAIL_CACHE_DIR = data_dir / ".thumb_cache"
+        app_module.app.config["TESTING"] = True
+
+        # folder_cover_rel_path should return the first sorted media file
+        cover = app_module.folder_cover_rel_path("photos")
+        assert cover is not None
+        assert "cover.png" in cover
+
+    def test_cover_respects_exclusions(self, monkeypatch, tmp_path):
+        """folder_cover_rel_path should skip excluded paths via iter_gallery_items."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / ".thumb_cache").mkdir(exist_ok=True)
+
+        # Create a subfolder with only an excluded media file
+        subfolder = data_dir / "photos"
+        subfolder.mkdir()
+        hidden_dir = subfolder / ".hidden"
+        hidden_dir.mkdir()
+        (hidden_dir / "secret.png").write_bytes(
+            b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01'
+            b'\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde'
+        )
+
+        monkeypatch.setenv("DATA_FOLDER", str(data_dir))
+        monkeypatch.setenv("AUTH_TYPE", "local")
+        monkeypatch.setenv("ADMIN_PASSWORD", "pass123")
+        monkeypatch.setenv("OIDC_ENABLED", "false")
+        monkeypatch.setenv("SECRET_KEY", "test-secret-ci-gateway")
+        monkeypatch.setenv("LLM_API_KEYS", "agent-key")
+        monkeypatch.setenv("GALLERY_AUTO_FOLDER_COVERS", "true")
+
+        for mod in ("auth", "app"):
+            sys.modules.pop(mod, None)
+
+        import app as app_module
+        app_module.DATA_FOLDER = data_dir
+        app_module.THUMBNAIL_CACHE_DIR = data_dir / ".thumb_cache"
+        app_module.app.config["TESTING"] = True
+
+        # Should return None since the only media file is in an excluded path
+        cover = app_module.folder_cover_rel_path("photos")
+        assert cover is None
+
+    def test_iter_gallery_items_root_parameter(self, monkeypatch, tmp_path):
+        """iter_gallery_items should accept root parameter for scoped scans."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / ".thumb_cache").mkdir(exist_ok=True)
+
+        # Create files in root and subfolder
+        (data_dir / "root_img.png").write_bytes(
+            b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01'
+            b'\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde'
+        )
+        subfolder = data_dir / "sub"
+        subfolder.mkdir()
+        (subfolder / "sub_img.png").write_bytes(
+            b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01'
+            b'\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde'
+        )
+
+        monkeypatch.setenv("DATA_FOLDER", str(data_dir))
+        monkeypatch.setenv("AUTH_TYPE", "local")
+        monkeypatch.setenv("ADMIN_PASSWORD", "pass123")
+        monkeypatch.setenv("OIDC_ENABLED", "false")
+        monkeypatch.setenv("SECRET_KEY", "test-secret-ci-gateway")
+        monkeypatch.setenv("LLM_API_KEYS", "agent-key")
+
+        for mod in ("auth", "app"):
+            sys.modules.pop(mod, None)
+
+        import app as app_module
+        app_module.DATA_FOLDER = data_dir
+        app_module.THUMBNAIL_CACHE_DIR = data_dir / ".thumb_cache"
+        app_module.app.config["TESTING"] = True
+
+        # Scanning from subfolder should only return files in that subfolder
+        items = app_module.iter_gallery_items(kind="media", root=subfolder)
+        assert len(items) == 1
+        assert items[0].name == "sub_img.png"
+
+        # Scanning from root should return both
+        all_items = app_module.iter_gallery_items(kind="media")
+        assert len(all_items) == 2


### PR DESCRIPTION
## What
Refactored `folder_cover_rel_path()` to delegate to `iter_gallery_items(kind="media", limit=1, path=folder)` instead of manually walking the directory with `rglob` and duplicating exclusion/media-check logic. Removed the local `GALLERY_SCAN_LIMIT` reference from the fu…

Fixes #325

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-325)._