### PR TITLE
Make gunicorn worker count configurable via WEB_CONCURRENCY env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,14 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app.py auth.py security.py tag_store.py trash.py health.py .//
 COPY templates/ templates/
+COPY entrypoint.sh .
 
 RUN mkdir -p /data
 
 EXPOSE 5000
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "app:app"]
+# Worker count is controlled by WEB_CONCURRENCY env var (default: 2).
+# NOTE: The in-memory rate limiter in security.py is NOT shared across workers.
+# With WEB_CONCURRENCY > 1, rate limiting is per-worker and less effective.
+# For accurate cross-worker rate limiting, configure REDIS_URL in security.py.
+ENTRYPOINT ["/bin/sh", "/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Entrypoint for miso-gallery container.
+#
+# WEB_CONCURRENCY controls the number of gunicorn workers.
+# Default is 2; set to 1 if you rely on the in-memory rate limiter
+# (security.py) which is not shared across multiple workers.
+# For production with Redis-backed rate limiting, increase as needed.
+
+set -e
+
+: "${WEB_CONCURRENCY:=2}"
+
+exec gunicorn \
+    --bind "0.0.0.0:${PORT:-5000}" \
+    --workers "$WEB_CONCURRENCY" \
+    app:app

--- a/tests/test_dockerfile_packaging.py
+++ b/tests/test_dockerfile_packaging.py
@@ -10,3 +10,43 @@ def test_dockerfile_packages_tag_store():
     ]
 
     assert any("tag_store.py" in command[1:-1] for command in copy_commands)
+
+
+def test_dockerfile_uses_entrypoint():
+    """Dockerfile should use entrypoint.sh instead of hardcoded CMD."""
+    dockerfile = Path("Dockerfile").read_text()
+    assert "entrypoint.sh" in dockerfile
+    assert "ENTRYPOINT" in dockerfile
+    # Should NOT have hardcoded workers in CMD
+    lines = [line.strip() for line in dockerfile.splitlines() if line.strip().startswith("CMD")]
+    assert not any("--workers" in line for line in lines), (
+        "Worker count should not be hardcoded in CMD"
+    )
+
+
+def test_dockerfile_documents_rate_limiter_limitation():
+    """Dockerfile should document the in-memory rate limiter limitation."""
+    dockerfile = Path("Dockerfile").read_text()
+    assert "rate limiter" in dockerfile.lower() or "rate limiting" in dockerfile.lower()
+
+
+def test_entrypoint_script_exists():
+    """entrypoint.sh must exist and be executable."""
+    entrypoint = Path("entrypoint.sh")
+    assert entrypoint.exists(), "entrypoint.sh is missing"
+    assert entrypoint.stat().st_mode & 0o111, "entrypoint.sh is not executable"
+
+
+def test_entrypoint_uses_web_concurrency():
+    """entrypoint.sh should read WEB_CONCURRENCY env var."""
+    entrypoint = Path("entrypoint.sh").read_text()
+    assert "WEB_CONCURRENCY" in entrypoint
+    assert "gunicorn" in entrypoint
+    # Should have a default value
+    assert ":=" in entrypoint or "${WEB_CONCURRENCY:-" in entrypoint
+
+
+def test_entrypoint_documents_rate_limiter_warning():
+    """entrypoint.sh should warn about in-memory rate limiter with multiple workers."""
+    entrypoint = Path("entrypoint.sh").read_text()
+    assert "rate limiter" in entrypoint.lower() or "rate limiting" in entrypoint.lower()


### PR DESCRIPTION
## What
Added entrypoint.sh script and updated Dockerfile to use ENTRYPOINT instead of hardcoded CMD, with documentation about rate limiter limitations across multiple workers.

## Why
The in-memory rate limiter in security.py is not shared across gunicorn workers, making rate…

Fixes #329

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-329)._