### PR TITLE
docs: recommend placing TAG_DATABASE outside DATA_FOLDER for NFS/snapshot backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ services:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `DATA_FOLDER` | No | `/data` | Path to image directory |
-| `TAG_DATABASE` | No | `$DATA_FOLDER/.miso-gallery-tags.sqlite3` | Path to the SQLite tag database |
+| `TAG_DATABASE` | No | `$DATA_FOLDER/.miso-gallery-tags.sqlite3` | Path to the SQLite tag database. **Recommended to set this outside `DATA_FOLDER`** on NFS or snapshot-based backups — see [Backup Considerations](docs/runbook.md#backup-considerations-tag-database-placement). |
 | `IMAGE_BASE_URL` | No | - | Base URL for shareable links |
 | `PORT` | No | `5000` | Server port |
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -43,6 +43,38 @@ This runbook documents the procedure for backing up and restoring images stored 
 
 Consider scheduling a cron job to perform regular backups.
 
+### Backup Considerations: Tag Database Placement
+
+By default, the SQLite tag database is created inside `DATA_FOLDER` at
+`$DATA_FOLDER/.miso-gallery-tags.sqlite3` (alongside its `-wal` and `-shm`
+sibling files). This means any backup, sync, or snapshot tool that walks
+`DATA_FOLDER` will also pick up the live database — and depending on the
+backup mechanism, the captured DB may be in an inconsistent state
+mid-transaction.
+
+For deployments where `DATA_FOLDER` lives on **NFS**, an **LVM/ZFS/Btrfs
+snapshot**, or any other **atomic-snapshot** storage, it is strongly
+recommended to relocate the tag database outside of `DATA_FOLDER` so the
+two can be backed up independently:
+
+```bash
+# Example: place the tag database in a dedicated, non-snapshotted path
+-e TAG_DATABASE=/var/lib/miso-gallery/tags.sqlite3
+```
+
+When `TAG_DATABASE` is set to a path outside `DATA_FOLDER`:
+
+- File-level backup tools (e.g. `rsync` of `DATA_FOLDER`) will no longer
+  include the DB, so back it up separately (e.g. via `sqlite3 .backup` or
+  by stopping the service long enough to copy the file).
+- Snapshot-based backups of `DATA_FOLDER` will not capture a half-written
+  database, eliminating the risk of restoring a corrupted SQLite file
+  alongside otherwise-valid media.
+
+The `TAG_DATABASE` environment variable was introduced for exactly this
+reason — it is supported on every release that ships with tagging and
+requires no code changes to use.
+
 ---
 
 ## Health Checks


### PR DESCRIPTION
## What
Adds documentation recommending placement of the SQLite tag database outside `DATA_FOLDER` for NFS/snapshot-based backup deployments. Updates the `TAG_DATABASE` env var description in `README.md` with a recommendation and cross-reference, and adds a new "Backup Conside…

Fixes #331

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-331)._