### PR TITLE
fix(pwa): don't mask failed media navigations

### DIFF
--- a/templates/service-worker.js
+++ b/templates/service-worker.js
@@ -31,6 +31,13 @@ self.addEventListener("fetch", (event) => {
   const requestUrl = new URL(request.url);
   if (requestUrl.origin !== self.location.origin) return;
 
+  // Let direct media navigations fail normally instead of disguising storage
+  // errors as a successful navigation to the cached gallery homepage.
+  const isMediaNavigation = ["/view/", "/images/", "/thumb/"].some((prefix) =>
+    requestUrl.pathname.startsWith(prefix)
+  );
+  if (request.mode === "navigate" && isMediaNavigation) return;
+
   if (request.destination === "image") {
     event.respondWith(
       caches.match(request).then((cached) => {

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 SERVICE_WORKER = Path(__file__).parents[1] / "templates" / "service-worker.js"
 
 

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+SERVICE_WORKER = Path(__file__).parents[1] / "templates" / "service-worker.js"
+
+
+def test_direct_media_navigations_bypass_offline_homepage_fallback():
+    script = SERVICE_WORKER.read_text()
+
+    bypass_position = script.index('request.mode === "navigate" && isMediaNavigation')
+    navigation_handler_position = script.index('if (request.mode === "navigate")')
+
+    assert bypass_position < navigation_handler_position
+    assert '["/view/", "/images/", "/thumb/"]' in script
+    assert 'if (request.mode === "navigate" && isMediaNavigation) return;' in script


### PR DESCRIPTION
## What changed

- bypass the service worker for top-level `/view/`, `/images/`, and `/thumb/` navigations
- preserve the existing offline homepage fallback for gallery page navigations
- add a regression test ensuring media navigations cannot reach the cached-homepage fallback

## Why

When a direct media navigation fails, the service worker currently catches the network error and falls back to cached `/`. That turns the underlying failure into a successful-looking redirect to the gallery homepage and obscures diagnosis. Direct media URLs should surface their real network/HTTP failure instead.

This PR intentionally does not attempt to fix the separate stale `/recent` listing behavior.

## Validation

- `node --check templates/service-worker.js`
- `python3 -m ruff check tests/test_service_worker.py`
- `python3 -m pytest -q` (142 passed)
