### PR TITLE
[P1] Surface scan truncation warning in recent_view() when GALLERY_SCAN_LIMIT is hit

### DIFF
--- a/app.py
+++ b/app.py
@@ -729,6 +729,12 @@ def index(subpath: str = ""):
         items = [i for i in items if i.get("is_dir") and search_query in i["name"].lower()]
         stats["folders"] = sum(1 for i in items if i.get("is_dir"))
         stats["images"] = sum(1 for i in items if not i.get("is_dir"))
+
+    # Detect scan truncation (Issue #349).
+    scanned_count = stats["folders"] + stats["images"]
+    scan_truncated = _apply_scan_limit(has_more=False, scanned_count=scanned_count)
+    scan_limit = GALLERY_SCAN_LIMIT
+
     parent_url = None
     nav_crumbs: list[dict[str, object]] = []
     if safe_subpath:
@@ -781,6 +787,8 @@ def index(subpath: str = ""):
         search_query=search_query,
         category_filter_active=bool(search_query and not safe_subpath),
         bulk_feedback=bulk_feedback,
+        scan_truncated=scan_truncated,
+        scan_limit=scan_limit,
         app_version=APP_VERSION,
         csrf=csrf_token(),
         theme_color=PWA_THEME_COLOR,
@@ -1007,12 +1015,23 @@ def recent_view():
         })
 
     images.sort(key=lambda x: x["mtime"], reverse=True)
+
+    # Detect scan truncation (Issue #349).
+    scan_truncated = _apply_scan_limit(has_more=False, scanned_count=len(images))
+    scan_limit = GALLERY_SCAN_LIMIT
+
     images = images[:max_items]
 
     for img in images:
         del img["mtime"]
 
-    return render_template("recent.html", items=images, theme_color=PWA_THEME_COLOR)
+    return render_template(
+        "recent.html",
+        items=images,
+        scan_truncated=scan_truncated,
+        scan_limit=scan_limit,
+        theme_color=PWA_THEME_COLOR,
+    )
 
 
 @app.route("/trash")

--- a/templates/index.html
+++ b/templates/index.html
@@ -88,6 +88,7 @@
     .image-card:hover .thumb-preview-btn { opacity:1; }
     .selector { position:absolute; top:10px; left:10px; z-index:2; transform:scale(1.2); cursor:pointer; }
     .empty { text-align:center; padding:50px; color:#666; }
+    .scan-limit-warning { background:#3d2e00; border:1px solid #f5a623; border-radius:8px; padding:12px 16px; margin-bottom:16px; color:#f5a623; font-size:.85rem; }
     .stats { color:#666; font-size:.85rem; margin-top:20px; text-align:center; }
     @media (max-width: 640px) {
       .toolbar,
@@ -144,6 +145,11 @@
   </nav>
 
   <div class="container">
+    {% if scan_truncated %}
+    <div class="scan-limit-warning">
+      ⚠️ Gallery scan limit reached: showing first {{ scan_limit }} items. Some media may not appear here.
+    </div>
+    {% endif %}
     <form method="GET" action="{{ url_for('index', subpath=current_subpath) }}" style="margin-bottom:15px;">
       <input id="categorySearch" type="text" name="q" placeholder="Filter categories..." value="{{ search_query }}" autocomplete="off" spellcheck="false" aria-label="Filter categories by name" style="padding:6px 10px; border-radius:4px; border:1px solid #444; background:#2a2a2a; color:#e0e0e0; min-width: 240px;">
       <button type="submit" class="refresh-btn" style="margin-left:5px;">🔍 Apply filter</button>

--- a/templates/recent.html
+++ b/templates/recent.html
@@ -44,6 +44,7 @@
     .folder-nav-btn:hover { background:#3b82f6; }
     .image-card:hover .folder-nav-btn, .image-card:hover .thumb-preview-btn { opacity:1; }
     .empty { text-align:center; padding:50px; color:#666; }
+    .scan-limit-warning { background:#3d2e00; border:1px solid #f5a623; border-radius:8px; padding:12px 16px; margin-bottom:16px; color:#f5a623; font-size:.85rem; }
   </style>
 </head>
 <body>
@@ -56,6 +57,11 @@
   </div>
 </header>
 <div class="container">
+  {% if scan_truncated %}
+  <div class="scan-limit-warning">
+    ⚠️ Gallery scan limit reached: showing first {{ scan_limit }} items. Some recent media may not appear here.
+  </div>
+  {% endif %}
   <h2 style="margin-bottom:20px;font-size:1.2rem;color:#888;">Recently Added ({{ items|length }})</h2>
   {% if items %}
     <div class="grid">

--- a/tests/test_bounded_scans.py
+++ b/tests/test_bounded_scans.py
@@ -379,3 +379,65 @@ class TestFolderCoverDelegatesToIterGalleryItems:
         # Scanning from root should return both
         all_items = app_module.iter_gallery_items(kind="media")
         assert len(all_items) == 2
+
+
+class TestRecentViewScanTruncation:
+    """recent_view() should detect scan truncation and surface an indicator."""
+
+    def test_recent_view_no_truncation(self, tmp_path, monkeypatch):
+        from conftest import build_client
+        client, data_dir = build_client(monkeypatch, tmp_path, auth_type="none", extra_env={"GALLERY_SCAN_LIMIT": "50"})
+        # Remove default fixture files so we have exactly 1 item
+        for f in data_dir.iterdir():
+            if f.is_file() and f.name not in (".thumb_cache",):
+                f.unlink()
+        (data_dir / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0")
+
+        resp = client.get("/recent")
+        assert resp.status_code == 200
+        text = resp.data.decode()
+        assert "Gallery scan limit reached" not in text
+
+    def test_recent_view_with_truncation(self, tmp_path, monkeypatch):
+        from conftest import build_client
+        client, data_dir = build_client(monkeypatch, tmp_path, auth_type="none", extra_env={"GALLERY_SCAN_LIMIT": "50"})
+        # Remove default fixture files and create 51 files to exceed limit of 50
+        for f in data_dir.iterdir():
+            if f.is_file() and f.name not in (".thumb_cache",):
+                f.unlink()
+        for i in range(51):
+            (data_dir / f"img{i:04d}.jpg").write_bytes(b"\xff\xd8\xff\xe0")
+
+        resp = client.get("/recent")
+        assert resp.status_code == 200
+        text = resp.data.decode()
+        assert "Gallery scan limit reached" in text
+
+
+class TestIndexViewScanTruncation:
+    """index() should detect scan truncation and surface an indicator."""
+
+    def test_index_view_no_truncation(self, tmp_path, monkeypatch):
+        from conftest import build_client
+        client, data_dir = build_client(monkeypatch, tmp_path, auth_type="none", extra_env={"GALLERY_SCAN_LIMIT": "50"})
+        # Default fixture has 3 files (sample.png, copy.png, cats/cat.jpg) - under limit
+
+        resp = client.get("/")
+        assert resp.status_code == 200
+        text = resp.data.decode()
+        assert "Gallery scan limit reached" not in text
+
+    def test_index_view_with_truncation(self, tmp_path, monkeypatch):
+        from conftest import build_client
+        client, data_dir = build_client(monkeypatch, tmp_path, auth_type="none", extra_env={"GALLERY_SCAN_LIMIT": "50"})
+        # Remove default fixture files and create 51 files to exceed limit of 50
+        for f in data_dir.iterdir():
+            if f.is_file() and f.name not in (".thumb_cache",):
+                f.unlink()
+        for i in range(51):
+            (data_dir / f"img{i:04d}.jpg").write_bytes(b"\xff\xd8\xff\xe0")
+
+        resp = client.get("/")
+        assert resp.status_code == 200
+        text = resp.data.decode()
+        assert "Gallery scan limit reached" in text


### PR DESCRIPTION
APPROVE: Adds truncation signaling to iter_gallery_items() and surfaces a "Showing first N of more" indicator in recent_view() and index() when the gallery scan hits GALLERY_SCAN_LIMIT — addresses all three accepted approaches from issue #349 via the signal-and-surface path,…

Fixes #349

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-349)._