### PR TITLE
Enable WAL mode in TagStore for concurrent worker access

### DIFF
--- a/tag_store.py
+++ b/tag_store.py
@@ -17,6 +17,10 @@ class TagStore:
         self.database_path.parent.mkdir(parents=True, exist_ok=True)
         connection = sqlite3.connect(str(self.database_path), timeout=30)
         try:
+            # Enable WAL mode for concurrent reader/writer access under multi-worker load.
+            # synchronous=NORMAL reduces fsync overhead while maintaining durability.
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA synchronous=NORMAL")
             connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS media_tags (

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -536,3 +536,17 @@ def test_tag_store_is_singleton(monkeypatch, tmp_path):
     store2 = _tag_store()
 
     assert store1 is store2, "_tag_store() should return the same instance on repeated calls"
+
+
+def test_tag_store_enables_wal_mode(tmp_path):
+    """Regression for #350: TagStore must enable WAL mode to avoid contention under concurrent workers."""
+    from tag_store import TagStore
+
+    store = TagStore(tmp_path / "tags.db")
+
+    # Verify WAL mode is enabled on the connection used by _connect
+    with store._connect() as conn:
+        journal_mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert journal_mode == "wal", (
+            f"Expected journal_mode=WAL for concurrent worker access, got {journal_mode}"
+        )


### PR DESCRIPTION
## What
Enables SQLite WAL mode and synchronous=NORMAL in `TagStore._connect()` so reader/writer access is concurrent under multi-worker gunicorn deployments, eliminating SQLITE_BUSY errors. Adds a regression test verifying `journal_mode == "wal"`.

## Why
Issue #350 reports t…

Fixes #350

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-350)._