### PR TITLE
Add HTTP Range-request support for video files in /thumb/ endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,9 @@ import contextlib
 import hashlib
 import html
 import json
+import mimetypes
 import os
+import re
 import secrets
 import shlex
 import subprocess
@@ -18,6 +20,7 @@ from flask import (
     redirect,
     render_template,
     request,
+    send_file,
     send_from_directory,
     session,
     url_for,
@@ -787,6 +790,58 @@ def index(subpath: str = ""):
     )
 
 
+def _serve_video_with_range(source_path: Path):
+    """Serve a video file with HTTP Range-request support for seeking/scrubbing.
+
+    Returns 206 Partial Content when a Range header is present, otherwise 200 OK
+    with the full file.
+    """
+    file_size = source_path.stat().st_size
+    range_header = request.headers.get("Range")
+
+    if not range_header:
+        # No Range header — serve the entire file
+        return send_file(str(source_path))
+
+    # Parse Range header (expect format: "bytes=start-end" or "bytes=start-")
+    match = re.match(r"bytes=(\d+)-(\d*)", range_header)
+    if not match:
+        # Invalid Range header — serve full file without Range processing
+        return send_file(str(source_path), conditional=False)
+
+    start = int(match.group(1))
+    end_str = match.group(2)
+    end = int(end_str) if end_str else file_size - 1
+
+    # Clamp to valid range
+    start = max(0, min(start, file_size - 1))
+    end = max(start, min(end, file_size - 1))
+
+    length = end - start + 1
+
+    def generate():
+        with open(source_path, "rb") as f:
+            f.seek(start)
+            remaining = length
+            while remaining > 0:
+                chunk_size = min(8192, remaining)
+                data = f.read(chunk_size)
+                if not data:
+                    break
+                yield data
+                remaining -= len(data)
+
+    mime_type = mimetypes.guess_type(str(source_path))[0] or "application/octet-stream"
+
+    response = make_response(generate())
+    response.status_code = 206
+    response.headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
+    response.headers["Content-Length"] = str(length)
+    response.headers["Content-Type"] = mime_type
+    response.headers["Accept-Ranges"] = "bytes"
+    return response
+
+
 @app.route("/thumb/<path:filename>")
 @rate_limit(max_requests=120, window=60)
 def thumb(filename: str):
@@ -799,9 +854,9 @@ def thumb(filename: str):
     cached_name = thumbnail_filename(rel_path, source_path)
     cached_path = THUMBNAIL_CACHE_DIR / cached_name
 
-    # Videos are served directly without thumbnailing.
+    # Videos are served directly with Range-request support for seeking/scrubbing.
     if source_path.suffix.lower() in VIDEO_EXTENSIONS:
-        return send_from_directory(str(DATA_FOLDER), rel_path)
+        return _serve_video_with_range(source_path)
 
     if not cached_path.exists():
         try:

--- a/tests/test_video_range_requests.py
+++ b/tests/test_video_range_requests.py
@@ -1,0 +1,96 @@
+"""Tests for HTTP Range-request support on video files served via /thumb/.
+
+Fixes #363: Video files served via /thumb/ lack Range-request support, breaking seek/scrub.
+"""
+from conftest import build_client
+
+
+def _build_client_with_video(monkeypatch, tmp_path):
+    """Build client with a small test video file."""
+    client, data_dir = build_client(monkeypatch, tmp_path, auth_type="none")
+
+    # Create a small "video" file (just bytes, not a real mp4)
+    video_dir = data_dir / "videos"
+    video_dir.mkdir(parents=True, exist_ok=True)
+    video_path = video_dir / "test.mp4"
+    # Write 10240 bytes of predictable data for range testing
+    video_path.write_bytes(bytes(range(256)) * 40)
+
+    return client, video_path
+
+
+def test_video_without_range_returns_200(monkeypatch, tmp_path):
+    """Video request without Range header should return full file with 200."""
+    client, _ = _build_client_with_video(monkeypatch, tmp_path)
+
+    resp = client.get("/thumb/videos/test.mp4")
+    assert resp.status_code == 200
+    assert len(resp.data) == 10240
+    # send_file advertises Accept-Ranges so clients know seeking is available
+    assert resp.headers.get("Accept-Ranges") == "bytes"
+
+
+def test_video_with_range_returns_206(monkeypatch, tmp_path):
+    """Video request with Range header should return 206 Partial Content."""
+    client, _ = _build_client_with_video(monkeypatch, tmp_path)
+
+    resp = client.get("/thumb/videos/test.mp4", headers={"Range": "bytes=0-1023"})
+    assert resp.status_code == 206
+    assert len(resp.data) == 1024
+    assert "Content-Range" in resp.headers
+    assert resp.headers["Content-Range"] == "bytes 0-1023/10240"
+    assert resp.headers["Content-Length"] == "1024"
+    assert resp.headers["Accept-Ranges"] == "bytes"
+
+
+def test_video_range_open_ended(monkeypatch, tmp_path):
+    """Range header with open-ended end (bytes=500-) should return to EOF."""
+    client, _ = _build_client_with_video(monkeypatch, tmp_path)
+
+    resp = client.get("/thumb/videos/test.mp4", headers={"Range": "bytes=500-"})
+    assert resp.status_code == 206
+    expected_length = 10240 - 500
+    assert len(resp.data) == expected_length
+    assert resp.headers["Content-Range"] == f"bytes 500-{expected_length + 499}/10240"
+
+
+def test_video_range_seeking_positions(monkeypatch, tmp_path):
+    """Test seeking to multiple positions (simulates scrubbing)."""
+    client, video_path = _build_client_with_video(monkeypatch, tmp_path)
+    full_data = video_path.read_bytes()
+
+    # Seek to three different positions
+    ranges = [
+        ("bytes=0-255", 0, 255),
+        ("bytes=5000-5100", 5000, 5100),
+        ("bytes=9000-", 9000, 10239),
+    ]
+
+    for range_header, expected_start, expected_end in ranges:
+        resp = client.get("/thumb/videos/test.mp4", headers={"Range": range_header})
+        assert resp.status_code == 206, f"Failed for Range: {range_header}"
+        chunk_data = resp.data
+        # Verify the returned bytes match the expected slice of the file
+        assert chunk_data == full_data[expected_start : expected_end + 1], (
+            f"Data mismatch for Range: {range_header}"
+        )
+
+
+def test_video_range_invalid_returns_200(monkeypatch, tmp_path):
+    """Invalid Range header should fall back to serving full file."""
+    client, _ = _build_client_with_video(monkeypatch, tmp_path)
+
+    resp = client.get("/thumb/videos/test.mp4", headers={"Range": "invalid"})
+    assert resp.status_code == 200
+    assert len(resp.data) == 10240
+
+
+def test_video_range_clamped_to_file_size(monkeypatch, tmp_path):
+    """Range exceeding file size should be clamped."""
+    client, _ = _build_client_with_video(monkeypatch, tmp_path)
+
+    resp = client.get("/thumb/videos/test.mp4", headers={"Range": "bytes=10200-20000"})
+    assert resp.status_code == 206
+    # Should be clamped to bytes 10200-10239 (40 bytes)
+    assert len(resp.data) == 40
+    assert "bytes 10200-10239/10240" in resp.headers["Content-Range"]


### PR DESCRIPTION
## What

Added HTTP Range-request support for video files served via the `/thumb/` endpoint, enabling video scrubbing/seeking in browsers.

## Why

The `/thumb/` endpoint was serving entire video files without supporting HTTP Range requests, preventing:
- Video seeking/scrubbi…

Fixes #363

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-363)._