### PR TITLE
[P2] Log warning and use constant-time comparison for plaintext ADMIN_PASSWORD

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import os
@@ -187,7 +188,14 @@ def verify_local_password(password: str) -> bool:
 
     Supports plaintext and hashed formats for migration:
     - plaintext: ADMIN_PASSWORD=***
-    - hashed: ADMIN_PASSWORD=*** or scrypt:...
+    - hashed: ADMIN_PASSWORD=pbkdf2:... or scrypt:...
+
+    SECURITY WARNING: Plaintext ADMIN_PASSWORD values are insecure.
+    Migrate to a hashed password by setting ADMIN_PASSWORD to a Werkzeug hash,
+    e.g., generated via::
+
+        python -c "from werkzeug.security import generate_password_hash; \
+print(generate_password_hash('your-password'))"
     """
     if not ADMIN_PASSWORD:
         return False
@@ -195,7 +203,14 @@ def verify_local_password(password: str) -> bool:
     stored = ADMIN_PASSWORD
     if stored.startswith(("pbkdf2:", "scrypt:")):
         return check_password_hash(stored, password)
-    return password == stored
+    # Plaintext fallback for migration support — log warning and use
+    # constant-time comparison to avoid timing side-channels.
+    logger.warning(
+        "Plaintext ADMIN_PASSWORD detected. This is insecure and will be "
+        "deprecated in a future release. Migrate to a hashed password by "
+        "setting ADMIN_PASSWORD to a Werkzeug hash (e.g., pbkdf2:sha256:...)."
+    )
+    return hmac.compare_digest(password, stored)
 
 
 def require_auth(view_fn):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 """Tests for OIDC token refresh functionality (issue #351)."""
 
+import logging
 import sys
 from pathlib import Path
 
@@ -179,3 +180,42 @@ def test_oidc_callback_stores_expiry_without_refresh(monkeypatch, tmp_path):
             app_module.verify_oidc_authorization = original_verify
     finally:
         app_module.oauth.oidc.authorize_access_token = original_authorize
+
+
+def test_verify_local_password_plaintext_warning(monkeypatch, tmp_path, caplog):
+    """verify_local_password logs a warning when plaintext ADMIN_PASSWORD is used."""
+    import auth as auth_module
+
+    monkeypatch.setattr(auth_module, "ADMIN_PASSWORD", "plaintext-secret")
+
+    with caplog.at_level(logging.WARNING, logger="auth"):
+        result = auth_module.verify_local_password("plaintext-secret")
+        assert result is True
+        assert "Plaintext ADMIN_PASSWORD detected" in caplog.text
+
+
+def test_verify_local_password_hashed_no_warning(monkeypatch, tmp_path, caplog):
+    """verify_local_password does not warn when a hashed password is used."""
+    from werkzeug.security import generate_password_hash
+
+    import auth as auth_module
+
+    hashed = generate_password_hash("hashed-secret")
+    monkeypatch.setattr(auth_module, "ADMIN_PASSWORD", hashed)
+
+    with caplog.at_level(logging.WARNING, logger="auth"):
+        result = auth_module.verify_local_password("hashed-secret")
+        assert result is True
+        assert "Plaintext ADMIN_PASSWORD detected" not in caplog.text
+
+
+def test_verify_local_password_plaintext_constant_time(monkeypatch, tmp_path):
+    """verify_local_password uses constant-time comparison for plaintext passwords."""
+    import auth as auth_module
+
+    monkeypatch.setattr(auth_module, "ADMIN_PASSWORD", "short")
+
+    # These should all return False without timing side-channels
+    assert auth_module.verify_local_password("longer-password") is False
+    assert auth_module.verify_local_password("shor") is False
+    assert auth_module.verify_local_password("short") is True


### PR DESCRIPTION
## What\nReplaces insecure `==` comparison of plaintext `ADMIN_PASSWORD` in `auth.verify_local_password` with constant-time `hmac.compare_digest`, logs a deprecation warning when plaintext is detected, documents the behavior in README.md, and adds three tests covering the warn…

Fixes #347

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-347)._