### PR TITLE
Fix: Ensure proper LRU eviction for folder cover cache

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ import secrets
 import shlex
 import subprocess
 import time
+from collections import OrderedDict
 from pathlib import Path
 
 from flask import (
@@ -151,7 +152,8 @@ WEBHOOK_TASK_PREFIX = "WEBHOOK_TASK_"
 AUTO_FOLDER_COVERS_ENABLED = os.environ.get("GALLERY_AUTO_FOLDER_COVERS", "false").strip().lower() in {"1", "true", "yes", "on"}
 FOLDER_COVER_CACHE_TTL = max(int(os.environ.get("GALLERY_COVER_CACHE_TTL", "3600") or 3600), 0)
 WEBHOOK_SECRET = os.environ.get("WEBHOOK_SECRET", "").strip()
-_FOLDER_COVER_CACHE: dict[str, tuple[float, str | None]] = {}
+_FOLDER_COVER_CACHE: OrderedDict[str, tuple[float, str | None]] = OrderedDict()
+_FOLDER_COVER_MAX_SIZE = 1024
 
 # Bounded pagination defaults for gallery endpoints
 GALLERY_PAGE_DEFAULT = 50
@@ -342,28 +344,55 @@ def folder_cover_rel_path(folder_rel_path: str) -> str | None:
     now = time.time()
     cached = _FOLDER_COVER_CACHE.get(folder_rel_path)
     if cached and now - cached[0] < FOLDER_COVER_CACHE_TTL:
+        # Move to end (most recently used) for LRU ordering.
+        _FOLDER_COVER_CACHE.move_to_end(folder_rel_path)
         cached_rel = cached[1]
-        if cached_rel:
-            cached_path = DATA_FOLDER / sanitize_rel_path(cached_rel)
-            if cached_path.exists() and cached_path.is_file() and cached_path.suffix.lower() in IMAGE_EXTENSIONS:
-                return cached_rel
-        else:
-            cached = None
+        if cached_rel is None:
+            # Short-circuit: folder was previously scanned and had no media.
+            return None
+        # Re-validate the backing file still exists and resolves within DATA_FOLDER.
+        try:
+            cached_path = (DATA_FOLDER / sanitize_rel_path(cached_rel)).resolve()
+            cached_path.relative_to(DATA_FOLDER.resolve())
+        except ValueError:
+            # Resolved path escapes DATA_FOLDER (e.g. symlink) — treat as missing.
+            _FOLDER_COVER_CACHE[folder_rel_path] = (now, None)
+            return None
+        if cached_path.exists() and cached_path.is_file() and cached_path.suffix.lower() in IMAGE_EXTENSIONS:
+            return cached_rel
+        # Stale entry — fall through to re-scan.
 
     folder_path = DATA_FOLDER / sanitize_rel_path(folder_rel_path) if folder_rel_path else DATA_FOLDER
     if not folder_path.exists() or not folder_path.is_dir():
         _FOLDER_COVER_CACHE[folder_rel_path] = (now, None)
+        while len(_FOLDER_COVER_CACHE) > _FOLDER_COVER_MAX_SIZE:
+            _FOLDER_COVER_CACHE.popitem(last=False)
         return None
 
     # Delegate to iter_gallery_items for bounded, exclusion-aware scanning.
     items = iter_gallery_items(kind="media", limit=1, root=folder_path)
 
     if not items:
-        _FOLDER_COVER_CACHE.pop(folder_rel_path, None)
+        _FOLDER_COVER_CACHE[folder_rel_path] = (now, None)
+        while len(_FOLDER_COVER_CACHE) > _FOLDER_COVER_MAX_SIZE:
+            _FOLDER_COVER_CACHE.popitem(last=False)
+        return None
+
+    # Validate the discovered cover resolves within DATA_FOLDER.
+    try:
+        resolved = items[0].resolve()
+        resolved.relative_to(DATA_FOLDER.resolve())
+    except ValueError:
+        # Symlink or other escape — treat as no cover.
+        _FOLDER_COVER_CACHE[folder_rel_path] = (now, None)
+        while len(_FOLDER_COVER_CACHE) > _FOLDER_COVER_MAX_SIZE:
+            _FOLDER_COVER_CACHE.popitem(last=False)
         return None
 
     cover_rel = items[0].relative_to(DATA_FOLDER).as_posix()
     _FOLDER_COVER_CACHE[folder_rel_path] = (now, cover_rel)
+    while len(_FOLDER_COVER_CACHE) > _FOLDER_COVER_MAX_SIZE:
+        _FOLDER_COVER_CACHE.popitem(last=False)
     return cover_rel
 
 

--- a/tests/test_folder_covers.py
+++ b/tests/test_folder_covers.py
@@ -1,6 +1,9 @@
 
+from unittest.mock import patch
+
 from PIL import Image
 
+from app import _FOLDER_COVER_MAX_SIZE, folder_cover_rel_path
 from conftest import build_client
 
 
@@ -44,8 +47,10 @@ def test_folder_card_uses_icon_when_auto_cover_disabled(monkeypatch, tmp_path):
 
 
 def test_folder_card_recovers_when_folder_gains_image_after_empty_cache(monkeypatch, tmp_path):
+    """When an empty folder gets a new image, the cover should appear after TTL expiry."""
     extra_env = {
         "GALLERY_AUTO_FOLDER_COVERS": "true",
+        "GALLERY_COVER_CACHE_TTL": "0",  # TTL=0 means every access re-validates
     }
     client, data_dir = build_client(monkeypatch, tmp_path, auth_type="none", extra_env=extra_env)
 
@@ -101,3 +106,90 @@ def test_folder_card_recovers_when_cached_preview_image_is_deleted(monkeypatch, 
     second_html = second.get_data(as_text=True)
     assert '/thumb/albums/trip/001.jpg' not in second_html
     assert '/thumb/albums/trip/002.jpg' in second_html
+
+
+def test_folder_cover_cache_lru_eviction(monkeypatch, tmp_path):
+    """Cache should evict oldest entries when exceeding max size."""
+    extra_env = {
+        "GALLERY_AUTO_FOLDER_COVERS": "true",
+        "GALLERY_COVER_CACHE_TTL": "3600",
+    }
+    client, data_dir = build_client(monkeypatch, tmp_path, auth_type="none", extra_env=extra_env)
+
+    from app import _FOLDER_COVER_CACHE as cache
+
+    cache.clear()
+
+    # Create more folders than the max cache size.
+    num_folders = _FOLDER_COVER_MAX_SIZE + 10
+    folder_names = []
+    for i in range(num_folders):
+        folder = data_dir / f"folder_{i}"
+        folder.mkdir(parents=True, exist_ok=True)
+        img = Image.new("RGB", (64, 64), color="red")
+        img.save(folder / "img.jpg")
+        folder_names.append(f"folder_{i}")
+
+    # Patch DATA_FOLDER so folder_cover_rel_path uses the test data dir.
+    with patch.object(__import__("app", fromlist=["DATA_FOLDER"]), "DATA_FOLDER", data_dir):
+        import app as app_mod
+
+        # Populate cache by calling folder_cover_rel_path for each folder.
+        for name in folder_names:
+            result = app_mod.folder_cover_rel_path(name)
+            assert result is not None, f"Expected cover for {name}"
+
+        # Cache should be bounded to max size.
+        assert len(cache) <= _FOLDER_COVER_MAX_SIZE
+
+        # The oldest entries should have been evicted.
+        # The most recently accessed folder should still be in cache.
+        assert app_mod.folder_cover_rel_path(folder_names[-1]) is not None
+
+
+def test_folder_card_symlink_escape_blocked(monkeypatch, tmp_path):
+    """Symlinks pointing outside DATA_FOLDER must not be served as covers."""
+    extra_env = {
+        "GALLERY_AUTO_FOLDER_COVERS": "true",
+        "GALLERY_COVER_CACHE_TTL": "3600",
+    }
+    client, data_dir = build_client(monkeypatch, tmp_path, auth_type="none", extra_env=extra_env)
+
+    # Create a target image outside DATA_FOLDER.
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    outside_img = Image.new("RGB", (64, 64), color="blue")
+    outside_img.save(outside_dir / "secret.jpg")
+
+    # Create a folder inside DATA_FOLDER with a symlink to the outside image.
+    folder = data_dir / "albums" / "gallery"
+    folder.mkdir(parents=True, exist_ok=True)
+    symlink_path = folder / "link.jpg"
+    try:
+        symlink_path.symlink_to(outside_dir / "secret.jpg")
+    except OSError:
+        # Symlinks may not be supported on this platform (e.g. Windows without admin).
+        return
+
+    resp = client.get("/")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    # The symlinked image should NOT appear as a cover.
+    assert "secret.jpg" not in html
+
+
+def test_folder_cover_null_byte_path(monkeypatch, tmp_path):
+    """Paths containing null bytes should be safely rejected."""
+    extra_env = {
+        "GALLERY_AUTO_FOLDER_COVERS": "true",
+        "GALLERY_COVER_CACHE_TTL": "3600",
+    }
+    build_client(monkeypatch, tmp_path, auth_type="none", extra_env=extra_env)
+
+    from app import _FOLDER_COVER_CACHE as cache
+
+    cache.clear()
+
+    # Null byte in path should return None (not crash or serve anything).
+    result = folder_cover_rel_path("albums\0evil")
+    assert result is None


### PR DESCRIPTION
## What

Bounded and hardened the in-memory `_FOLDER_COVER_CACHE` used by `folder_cover_rel_path()` so it no longer serves stale nonexistent paths and cannot grow unboundedly.

## Why

The cache stored `(timestamp, rel_path)` tuples with a TTL but had three defects: (1) it was…

Fixes #348

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-348)._