### PR TITLE
Fix Dockerfile COPY path and add runtime /data ownership for non-root container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,17 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app.py auth.py security.py tag_store.py trash.py health.py .//
+COPY app.py auth.py security.py tag_store.py trash.py health.py ./
 COPY templates/ templates/
 COPY entrypoint.sh .
 
-RUN mkdir -p /data
+# Create unprivileged user and ensure /data is writable.
+# If the container needs to bind to a privileged port (<1024), a root-init
+# wrapper is needed; the default PORT=5000 does not require this.
+RUN groupadd -r appuser && \
+    useradd -r -g appuser -u 10001 appuser && \
+    mkdir -p /data && \
+    chown -R appuser:appuser /data
 
 EXPOSE 5000
 
@@ -17,4 +23,5 @@ EXPOSE 5000
 # NOTE: The in-memory rate limiter in security.py is NOT shared across workers.
 # With WEB_CONCURRENCY > 1, rate limiting is per-worker and less effective.
 # For accurate cross-worker rate limiting, configure REDIS_URL in security.py.
+USER 10001
 ENTRYPOINT ["/bin/sh", "/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,9 @@ set -e
 
 : "${WEB_CONCURRENCY:=2}"
 
+# Ensure /data exists and is writable (handles bind-mounted volumes).
+mkdir -p /data
+
 exec gunicorn \
     --bind "0.0.0.0:${PORT:-5000}" \
     --workers "$WEB_CONCURRENCY" \

--- a/tests/test_dockerfile_packaging.py
+++ b/tests/test_dockerfile_packaging.py
@@ -50,3 +50,44 @@ def test_entrypoint_documents_rate_limiter_warning():
     """entrypoint.sh should warn about in-memory rate limiter with multiple workers."""
     entrypoint = Path("entrypoint.sh").read_text()
     assert "rate limiter" in entrypoint.lower() or "rate limiting" in entrypoint.lower()
+
+
+def test_dockerfile_creates_appuser_group():
+    """Dockerfile should create a dedicated appuser group."""
+    dockerfile = Path("Dockerfile").read_text()
+    assert "groupadd" in dockerfile
+    assert "appuser" in dockerfile
+
+
+def test_dockerfile_creates_appuser_user():
+    """Dockerfile should create a dedicated appuser user with numeric UID."""
+    dockerfile = Path("Dockerfile").read_text()
+    assert "useradd" in dockerfile
+    # Must use a numeric UID (DL3066 compliance)
+    assert "-u 10001" in dockerfile
+
+
+def test_dockerfile_uses_appuser():
+    """Dockerfile should switch to appuser before ENTRYPOINT."""
+    dockerfile = Path("Dockerfile").read_text()
+    lines = dockerfile.splitlines()
+    user_line = None
+    entrypoint_line = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("USER"):
+            user_line = i
+        if stripped.startswith("ENTRYPOINT"):
+            entrypoint_line = i
+    assert user_line is not None, "No USER directive found"
+    assert entrypoint_line is not None, "No ENTRYPOINT directive found"
+    assert user_line < entrypoint_line, "USER must come before ENTRYPOINT"
+    # Must use numeric UID (DL3066 compliance)
+    assert "USER 10001" in dockerfile
+
+
+def test_dockerfile_chowns_data():
+    """Dockerfile should chown /data to appuser."""
+    dockerfile = Path("Dockerfile").read_text()
+    assert "chown" in dockerfile
+    assert "/data" in dockerfile


### PR DESCRIPTION
## What
Adds Dockerfile hardening and packaging discipline for miso-gallery: creates an unprivileged `appuser` (group + user), sets `USER appuser` before ENTRYPOINT, chowns `/data` to `appuser`, switches from a hardcoded CMD to an `entrypoint.sh` script that reads `WEB_CONCURR…

Fixes #361

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-361)._