### PR TITLE
Add task name character validation to prevent env var collision and injection

### DIFF
--- a/app.py
+++ b/app.py
@@ -149,6 +149,7 @@ PWA_THEME_COLOR = "#0d0d0d"
 PWA_APP_NAME = "Miso Gallery"
 APP_VERSION = (os.environ.get("APP_VERSION") or "0.1.19").strip() or "0.1.19"
 WEBHOOK_TASK_PREFIX = "WEBHOOK_TASK_"
+_VALID_TASK_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 AUTO_FOLDER_COVERS_ENABLED = os.environ.get("GALLERY_AUTO_FOLDER_COVERS", "false").strip().lower() in {"1", "true", "yes", "on"}
 FOLDER_COVER_CACHE_TTL = max(int(os.environ.get("GALLERY_COVER_CACHE_TTL", "3600") or 3600), 0)
 WEBHOOK_SECRET = os.environ.get("WEBHOOK_SECRET", "").strip()
@@ -213,6 +214,20 @@ def _verify_webhook_secret(token: str) -> bool:
 def _task_env_key(task_name: str) -> str:
     normalized = "".join(ch if ch.isalnum() else "_" for ch in task_name).strip("_").upper()
     return f"{WEBHOOK_TASK_PREFIX}{normalized}" if normalized else ""
+
+
+def _validate_task_name(task_name: str) -> str | None:
+    """Validate that a task name only contains safe characters.
+
+    Returns an error message string if validation fails, or None if valid.
+    Only [a-zA-Z0-9_-] are permitted to prevent env var key collision and injection.
+    """
+    if not _VALID_TASK_RE.match(task_name):
+        return (
+            f"Invalid task name: '{task_name}'. "
+            "Task names may only contain letters, digits, hyphens, and underscores."
+        )
+    return None
 
 
 def _render_task_command(template: str, params: dict[str, object]) -> str:
@@ -598,6 +613,10 @@ def run_configured_task(payload: dict[str, object]) -> tuple[dict[str, object], 
         return {"error": "task is required"}, 400
     if not isinstance(params, dict):
         return {"error": "params must be an object"}, 400
+
+    validation_error = _validate_task_name(task)
+    if validation_error is not None:
+        return {"error": validation_error}, 400
 
     env_key = _task_env_key(task)
     if not env_key:
@@ -1522,7 +1541,13 @@ def llm_dedup():
 @require_api_key_with_scope("write")
 @rate_limit(max_requests=10, window=60)
 def llm_task_run():
-    body, status = run_configured_task(request.get_json(silent=True) or {})
+    data = request.get_json(silent=True) or {}
+    task = data.get("task", "")
+    if task:
+        validation_error = _validate_task_name(task)
+        if validation_error is not None:
+            return {"error": validation_error}, 400
+    body, status = run_configured_task(data)
     _invalidate_gallery_scan_cache()
     return body, status
 

--- a/tests/test_webhook_tasks.py
+++ b/tests/test_webhook_tasks.py
@@ -47,3 +47,85 @@ def test_webhook_task_returns_404_when_disabled(monkeypatch, tmp_path):
     resp = client.post("/api/webhook/run", json={"task": "generate", "params": {}})
 
     assert resp.status_code == 404
+
+
+def test_webhook_task_rejects_special_characters(monkeypatch, tmp_path):
+    client = _build_webhook_client(
+        monkeypatch, tmp_path,
+        task_cmd="echo hi",
+    )
+    resp = client.post("/api/webhook/run", json={"task": "ANYTHING_GOES_HERE!!!", "params": {}})
+
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert "Invalid task name" in payload["error"]
+
+
+def test_webhook_task_rejects_spaces(monkeypatch, tmp_path):
+    client = _build_webhook_client(
+        monkeypatch, tmp_path,
+        task_cmd="echo hi",
+    )
+    resp = client.post("/api/webhook/run", json={"task": "my task name", "params": {}})
+
+    assert resp.status_code == 400
+
+
+def test_webhook_task_rejects_dots(monkeypatch, tmp_path):
+    client = _build_webhook_client(
+        monkeypatch, tmp_path,
+        task_cmd="echo hi",
+    )
+    resp = client.post("/api/webhook/run", json={"task": "my.task.name", "params": {}})
+
+    assert resp.status_code == 400
+
+
+def test_webhook_task_rejects_path_traversal(monkeypatch, tmp_path):
+    client = _build_webhook_client(
+        monkeypatch, tmp_path,
+        task_cmd="echo hi",
+    )
+    resp = client.post("/api/webhook/run", json={"task": "../etc/passwd", "params": {}})
+
+    assert resp.status_code == 400
+
+
+def test_webhook_task_accepts_valid_characters(monkeypatch, tmp_path):
+    """Test that task names with hyphens and underscores pass validation."""
+    # The env key normalizes hyphens to underscores, so WEBHOOK_TASK_MY_VALID_TASK123
+    # matches task name "my-valid_task123" after normalization.
+    extra_env = {
+        "WEBHOOK_ENABLED": "true",
+        "WEBHOOK_TASK_MY_VALID_TASK123": 'python3 -c "import sys;print(\'ok-\'+sys.argv[1])" {params.name}',
+    }
+    client, _ = build_client(monkeypatch, tmp_path, auth_type="none", extra_env=extra_env)
+    resp = client.post("/api/webhook/run", json={"task": "my-valid_task123", "params": {"name": "test"}})
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["stdout"].strip() == "ok-test"
+
+
+def test_webhook_task_rejects_at_sign(monkeypatch, tmp_path):
+    client = _build_webhook_client(
+        monkeypatch, tmp_path,
+        task_cmd="echo hi",
+    )
+    resp = client.post("/api/webhook/run", json={"task": "bad@task#name!", "params": {}})
+
+    assert resp.status_code == 400
+
+
+def test_webhook_task_rejects_null_bytes(monkeypatch, tmp_path):
+    """Explicitly test null byte rejection for defense-in-depth documentation."""
+    client = _build_webhook_client(
+        monkeypatch, tmp_path,
+        task_cmd="echo hi",
+    )
+    resp = client.post("/api/webhook/run", json={"task": "task\0evil", "params": {}})
+
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert "Invalid task name" in payload["error"]


### PR DESCRIPTION
## What

Added `_validate_task_name()` in `app.py` that enforces a strict `[a-zA-Z0-9_-]+` regex on the `task` parameter, and invoked it in `run_configured_task()` before any env-var lookup. Added a matching test in `tests/test_webhook_tasks.py` asserting that `task: "ANYTHING…

Fixes #362

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-362)._