### PR TITLE
Fix trash_purge() silently swallowing invalid days input

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import contextlib
 import hashlib
 import html
 import json
+import logging
 import mimetypes
 import os
 import re
@@ -17,6 +18,7 @@ from pathlib import Path
 from flask import (
     Flask,
     abort,
+    flash,
     jsonify,
     make_response,
     redirect,
@@ -64,6 +66,8 @@ from trash import (
 SERVICE_WORKER_PATH = os.path.join(os.path.dirname(__file__), "templates", "service-worker.js")
 with open(SERVICE_WORKER_PATH, "r") as _f:
     SERVICE_WORKER_TEMPLATE = _f.read()
+
+log = logging.getLogger("app")
 
 
 DATA_FOLDER = Path(os.environ.get("DATA_FOLDER", "/data"))
@@ -1225,6 +1229,11 @@ def trash_purge():
     try:
         retention_days = max(1, min(3650, int(days)))
     except ValueError:
+        log.warning(
+            "Invalid 'days' value '%s' submitted to trash purge; using default of 30 days",
+            days,
+        )
+        flash("Invalid retention period provided; using default of 30 days.", "warning")
         retention_days = 30
     purge_old_trash(DATA_FOLDER, retention_days)
     _invalidate_gallery_scan_cache()

--- a/templates/trash.html
+++ b/templates/trash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><meta name=\"theme-color\" content=\"{{ theme_color }}\"><link rel=\"manifest\" href=\"/manifest.webmanifest\"><link rel=\"apple-touch-icon\" href=\"/assets/icon-192.png\"><meta name=\"apple-mobile-web-app-capable\" content=\"yes\"><meta name=\"apple-mobile-web-app-status-bar-style\" content=\"black-translucent\"><meta name=\"apple-mobile-web-app-title\" content=\"Miso Gallery\"><meta name=\"mobile-web-app-capable\" content=\"yes\"><title>Trash - Miso Gallery</title>
+<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><meta name="theme-color" content="{{ theme_color }}"><link rel="manifest" href="/manifest.webmanifest"><link rel="apple-touch-icon" href="/assets/icon-192.png"><meta name="apple-mobile-web-app-capable" content="yes"><meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"><meta name="apple-mobile-web-app-title" content="Miso Gallery"><meta name="mobile-web-app-capable" content="yes"><title>Trash - Miso Gallery</title>
 <style>
  body{background:#0d0d0d;color:#e0e0e0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:0}
  .wrap{max-width:1000px;margin:0 auto;padding:24px}
@@ -8,13 +8,30 @@
  th,td{padding:10px;border-bottom:1px solid #333;text-align:left}
  button{padding:8px 12px;border-radius:6px;border:1px solid #444;background:#222;color:#eee;cursor:pointer}
  .danger{background:#8b1e2b;border-color:#b91c1c}
+ input[type="number"]{padding:6px 8px;border-radius:6px;border:1px solid #444;background:#222;color:#eee;width:80px}
+ .alert{padding:10px 14px;margin-bottom:16px;border-radius:6px}
+ .alert-warning{background:#5c3d0e;border:1px solid #f59e0b;color:#fef3c7}
 </style></head>
-<body><div class=\"wrap\">
+<body><div class="wrap">
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            <div class="alert alert-{{ category }}">{{ message }}</div>
+        {% endfor %}
+    {% endif %}
+  {% endwith %}
   <h2>🗑️ Trash</h2>
-  <p><a href=\"/\">← Back to Gallery</a></p>
-  <form method=\"POST\" action=\"/trash/empty\" onsubmit=\"return confirm('Permanently delete all trashed items?')\">
-    <input type=\"hidden\" name=\"csrf_token\" value=\"{{ csrf }}\">
-    <button class=\"danger\" type=\"submit\">Empty Trash</button>
+  <p><a href="/">← Back to Gallery</a></p>
+  <form method="POST" action="/trash/empty" onsubmit="return confirm('Permanently delete all trashed items?')">
+    <input type="hidden" name="csrf_token" value="{{ csrf }}">
+    <button class="danger" type="submit">Empty Trash</button>
+  </form>
+  <form method="POST" action="/trash/purge" style="margin-top:12px;display:inline-flex;align-items:center;gap:8px">
+    <input type="hidden" name="csrf_token" value="{{ csrf }}">
+    <label for="purge_days">Purge items older than</label>
+    <input type="number" id="purge_days" name="days" min="1" max="3650" value="30">
+    <span>days</span>
+    <button class="danger" type="submit">Purge Old Trash</button>
   </form>
   <table>
     <thead><tr><th>File</th><th>Original Path</th><th>Deleted At</th><th>Size</th><th>Action</th></tr></thead>
@@ -26,9 +43,9 @@
         <td>{{ item.deleted_at }}</td>
         <td>{{ item.size }}</td>
         <td>
-          <form method=\"POST\" action=\"/trash/restore/{{ item.name }}\" style=\"display:inline\">
-            <input type=\"hidden\" name=\"csrf_token\" value=\"{{ csrf }}\">
-            <button type=\"submit\">Restore</button>
+          <form method="POST" action="/trash/restore/{{ item.name }}" style="display:inline">
+            <input type="hidden" name="csrf_token" value="{{ csrf }}">
+            <button type="submit">Restore</button>
           </form>
         </td>
       </tr>

--- a/tests/test_folder_trash.py
+++ b/tests/test_folder_trash.py
@@ -13,8 +13,11 @@ Covers:
 
 from __future__ import annotations
 
+import contextlib
 import re
 import time
+
+import pytest
 
 from conftest import build_client
 
@@ -362,3 +365,96 @@ class TestDirSizeSymlinkConsistency:
         assert trash_items[0]["size"] == 50, (
             f"Expected 50 bytes (symlinks skipped), got {trash_items[0]['size']}"
         )
+
+
+class TestTrashPurgeValidation:
+    """Verify trash_purge() validates days input and provides user feedback (regression for #364)."""
+
+    @pytest.fixture(autouse=True)
+    def reset_rate_limiters(self):
+        """Reset rate limiter state before each test to avoid cross-test interference."""
+        from security import FALLBACK_LIMITER, _primary_limiter
+
+        FALLBACK_LIMITER.reset()
+        if _primary_limiter is not None:
+            with contextlib.suppress(Exception):
+                _primary_limiter._client.flushdb()
+
+    def test_trash_purge_invalid_days_logs_warning_and_flashes(self, monkeypatch, tmp_path, caplog):
+        client, data_dir = build_client(monkeypatch, tmp_path)
+
+        # Create a trashed item to purge
+        folder = data_dir / "purge_me"
+        folder.mkdir()
+        (folder / "file.jpg").write_bytes(b"fakesize")
+        from trash import move_to_trash
+
+        move_to_trash(folder, data_dir)
+
+        # Login first
+        login_resp = client.get("/login")
+        csrf_match = re.search(r'name="csrf_token" value="([^"]+)"', login_resp.data.decode())
+        assert csrf_match, "CSRF token not found in login form"
+        login_csrf = csrf_match.group(1)
+        auth_resp = client.post(
+            "/auth",
+            data={"password": "pass123", "next": "/", "csrf_token": login_csrf},
+            follow_redirects=False,
+        )
+        assert auth_resp.status_code == 302
+
+        # Get CSRF token from trash page
+        trash_resp = client.get("/trash")
+        csrf_match = re.search(r'name="csrf_token" value="([^"]+)"', trash_resp.data.decode())
+        assert csrf_match, "CSRF token not found on trash page"
+        csrf_token = csrf_match.group(1)
+
+        # Submit invalid days value
+        with caplog.at_level("WARNING"):
+            response = client.post(
+                "/trash/purge",
+                data={"csrf_token": csrf_token, "days": "abc"},
+                follow_redirects=True,
+            )
+
+        assert response.status_code == 200
+        # Verify flash message is present in the rendered page
+        assert b"Invalid retention period" in response.data
+        # Verify a warning was logged about the invalid input
+        assert any("Invalid 'days' value" in record.message for record in caplog.records)
+
+    def test_trash_purge_valid_days(self, monkeypatch, tmp_path):
+        client, data_dir = build_client(monkeypatch, tmp_path)
+
+        # Create a trashed item
+        folder = data_dir / "purge_me2"
+        folder.mkdir()
+        (folder / "file.jpg").write_bytes(b"fakesize")
+        from trash import move_to_trash
+
+        move_to_trash(folder, data_dir)
+
+        # Login first
+        login_resp = client.get("/login")
+        csrf_match = re.search(r'name="csrf_token" value="([^"]+)"', login_resp.data.decode())
+        assert csrf_match, "CSRF token not found in login form"
+        login_csrf = csrf_match.group(1)
+        auth_resp = client.post(
+            "/auth",
+            data={"password": "pass123", "next": "/", "csrf_token": login_csrf},
+            follow_redirects=False,
+        )
+        assert auth_resp.status_code == 302
+
+        # Get CSRF token from trash page
+        trash_resp = client.get("/trash")
+        csrf_match = re.search(r'name="csrf_token" value="([^"]+)"', trash_resp.data.decode())
+        assert csrf_match, "CSRF token not found on trash page"
+        csrf_token = csrf_match.group(1)
+
+        response = client.post(
+            "/trash/purge",
+            data={"csrf_token": csrf_token, "days": "7"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302


### PR DESCRIPTION
## What

Adds input validation, user feedback, and logging to the `trash_purge()` endpoint so that non-numeric `days` values no longer silently fall back to 30 days.

## Why

The `trash_purge()` endpoint previously called `int(days)` inside a bare try/except with no logging an…

Fixes #364

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-364)._