### PR TITLE
Fix path traversal in /trash/restore (#382)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1199,7 +1199,13 @@ def trash_restore(item_name: str):
         log_security_event("trash_restore", "denied", reason="invalid_csrf")
         return {"error": "Invalid CSRF token"}, 403
 
-    restored = restore_from_trash(item_name, DATA_FOLDER)
+    try:
+        restored = restore_from_trash(item_name, DATA_FOLDER)
+    except ValueError as exc:
+        log_security_event("trash_restore", "denied", reason=str(exc), item=item_name)
+        flash(str(exc), "error")
+        return redirect(url_for("trash_view"))
+
     log_security_event("trash_restore", "success" if restored else "not_found", item=item_name)
     _invalidate_gallery_scan_cache()
     return redirect(url_for("trash_view"))

--- a/tests/test_folder_trash.py
+++ b/tests/test_folder_trash.py
@@ -14,6 +14,7 @@ Covers:
 from __future__ import annotations
 
 import contextlib
+import json
 import re
 import time
 
@@ -272,6 +273,110 @@ class TestTrashRestore:
         assert folder.exists()
         assert (folder / "file1.jpg").read_bytes() == content_before["file1.jpg"]
         assert (nested / "file2.jpg").read_bytes() == content_before["subdir/file2.jpg"]
+
+
+class TestRestorePathTraversal:
+    """Regression tests for path traversal in restore_from_trash (#382).
+
+    The <path:> converter in Flask allows / and .., so a crafted item_name
+    could escape the trash directory. These tests verify that traversal
+    attempts are rejected.
+    """
+
+    def test_restore_rejects_dotdot_in_name(self, monkeypatch, tmp_path):
+        from trash import restore_from_trash
+
+        client, data_dir = build_client(monkeypatch, tmp_path)
+
+        # Create a file outside the trash dir that an attacker might target
+        secret = data_dir / "secret.txt"
+        secret.write_text("top_secret")
+
+        with pytest.raises(ValueError, match="Invalid trash item name"):
+            restore_from_trash("../secret.txt", data_dir)
+
+        # Verify the secret file was not moved
+        assert secret.exists()
+        assert secret.read_text() == "top_secret"
+
+    def test_restore_rejects_double_dotdot(self, monkeypatch, tmp_path):
+        from trash import restore_from_trash
+
+        client, data_dir = build_client(monkeypatch, tmp_path)
+
+        # Create a file outside the data dir entirely
+        external = tmp_path / "external_secret.txt"
+        external.write_text("external_data")
+
+        with pytest.raises(ValueError, match="Invalid trash item name"):
+            restore_from_trash("../../external_secret.txt", data_dir)
+
+        # Verify the external file was not touched
+        assert external.exists()
+        assert external.read_text() == "external_data"
+
+    def test_restore_rejects_slash_in_name(self, monkeypatch, tmp_path):
+        from trash import restore_from_trash
+
+        client, data_dir = build_client(monkeypatch, tmp_path)
+
+        with pytest.raises(ValueError, match="Invalid trash item name"):
+            restore_from_trash("subdir/file.txt", data_dir)
+
+    def test_restore_rejects_backslash_in_name(self, monkeypatch, tmp_path):
+        from trash import restore_from_trash
+
+        client, data_dir = build_client(monkeypatch, tmp_path)
+
+        with pytest.raises(ValueError, match="Invalid trash item name"):
+            restore_from_trash("subdir\\file.txt", data_dir)
+
+    def test_restore_rejects_mixed_traversal(self, monkeypatch, tmp_path):
+        from trash import restore_from_trash
+
+        client, data_dir = build_client(monkeypatch, tmp_path)
+
+        with pytest.raises(ValueError, match="Invalid trash item name"):
+            restore_from_trash("foo/../../../etc/passwd", data_dir)
+
+    def test_restore_rejects_malicious_meta_original(self, monkeypatch, tmp_path):
+        """Even if item_name is valid, a crafted .meta.json 'original' must not escape."""
+        from trash import restore_from_trash, trash_dir
+
+        client, data_dir = build_client(monkeypatch, tmp_path)
+
+        td = trash_dir(data_dir)
+        td.mkdir(parents=True, exist_ok=True)
+
+        # Create a valid-looking item in trash with a malicious meta
+        fake_item = td / "fake_item.txt"
+        fake_item.write_text("harmless")
+        meta_file = td / "fake_item.txt.meta.json"
+        meta_file.write_text(
+            json.dumps({"original": "../../../etc/passwd", "deleted_at": 0})
+        )
+
+        with pytest.raises(ValueError, match="Invalid original path"):
+            restore_from_trash("fake_item.txt", data_dir)
+
+    def test_restore_rejects_meta_original_dotdot(self, monkeypatch, tmp_path):
+        """Meta 'original' with .. segments must be rejected."""
+        from trash import restore_from_trash, trash_dir
+
+        client, data_dir = build_client(monkeypatch, tmp_path)
+
+        td = trash_dir(data_dir)
+        td.mkdir(parents=True, exist_ok=True)
+
+        fake_item = td / "fake2.txt"
+        fake_item.write_text("harmless")
+        meta_file = td / "fake2.txt.meta.json"
+        meta_file.write_text(
+            json.dumps({"original": "../outside_trash.txt", "deleted_at": 0})
+        )
+
+        with pytest.raises(ValueError, match="Invalid original path"):
+            restore_from_trash("fake2.txt", data_dir)
 
 
 class TestTrashListIncludesDirs:

--- a/trash.py
+++ b/trash.py
@@ -145,11 +145,34 @@ def list_trash(data_folder: Path) -> list[dict]:
     return out
 
 
+def _is_safe_relative_path(path_str: str) -> bool:
+    """Return True if *path_str* contains no path-traversal segments."""
+    return all(part != ".." for part in path_str.replace("\\", "/").split("/"))
+
+
 def restore_from_trash(item_name: str, data_folder: Path) -> bool:
+    """Restore an item from trash to its original location.
+
+    Returns True if restored, False if not found or invalid.
+    Raises ValueError if *item_name* contains path traversal sequences.
+    """
+    # Reject path traversal in item_name (Flask's <path:> converter allows / and ..)
+    if "/" in item_name or "\\" in item_name or ".." in item_name:
+        raise ValueError(f"Invalid trash item name: {item_name!r}")
+
     td = trash_dir(data_folder)
     item = td / item_name
     if not item.exists():
         return False
+
+    # Verify resolved path stays within the trash directory
+    try:
+        resolved_item = item.resolve()
+        resolved_td = td.resolve()
+    except OSError:
+        return False
+    if not (str(resolved_item).startswith(str(resolved_td) + "/") or resolved_item == resolved_td):
+        raise ValueError(f"Item path escapes trash directory: {item_name!r}")
 
     meta_file = _meta_path(item)
     try:
@@ -157,7 +180,17 @@ def restore_from_trash(item_name: str, data_folder: Path) -> bool:
         rel = meta.get("original")
         if not rel:
             return False
+        # Validate original path doesn't escape data_folder
+        if not _is_safe_relative_path(rel):
+            raise ValueError(f"Invalid original path in meta: {rel!r}")
         dest = data_folder / rel
+        try:
+            resolved_dest = dest.resolve()
+            resolved_data = data_folder.resolve()
+        except OSError:
+            return False
+        if not (str(resolved_dest).startswith(str(resolved_data) + "/") or resolved_dest == resolved_data):
+            raise ValueError(f"Destination path escapes data folder: {rel!r}")
         dest.parent.mkdir(parents=True, exist_ok=True)
         if dest.exists():
             ts = int(time.time())
@@ -171,6 +204,8 @@ def restore_from_trash(item_name: str, data_folder: Path) -> bool:
         if meta_file.exists():
             meta_file.unlink(missing_ok=True)
         return True
+    except ValueError:
+        raise
     except Exception:
         return False
 


### PR DESCRIPTION
## What

Adds path-traversal protection to the trash restore flow in `trash.py` and corresponding tests.

## Why

`restore_from_trash()` accepted any `item_name` from the `<path:>` Flask converter (which allows `/` and `..`) and used the `.meta.json` `original` field without v…

Fixes #382

_Opened by foreman on review GO (workload wl-misospace-miso-gallery-382)._