### PR TITLE
fix(release): recover already-bumped unpublished versions

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Commit and push release branch
         id: branch
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
@@ -84,11 +85,22 @@ jobs:
           git config user.name "smurf-bot[bot]"
           git config user.email "smurf-bot[bot]@users.noreply.github.com"
           git add app.py
+          if git diff --cached --quiet; then
+            CURRENT_VERSION=$(python3 scripts/read_app_version.py)
+            if [ "$CURRENT_VERSION" != "$VERSION" ]; then
+              echo "APP_VERSION is $CURRENT_VERSION, expected $VERSION"
+              exit 1
+            fi
+            echo "APP_VERSION is already $VERSION; publishing from current main"
+            echo "publish_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           git commit -m "chore(release): bump version to ${VERSION}"
           git push origin "HEAD:refs/heads/${BRANCH}"
           echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Open release PR and enable auto-merge
+        if: steps.branch.outputs.name != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: ${{ steps.branch.outputs.name }}
@@ -102,3 +114,16 @@ jobs:
             --body "Version bump for release ${VERSION}. The release will be published after this PR passes the required checks and merges.")
           gh pr merge "$PR_URL" --auto --squash --delete-branch
           echo "Release PR: $PR_URL"
+
+      - name: Publish already-bumped release
+        if: steps.branch.outputs.publish_sha != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.version.outputs.version }}
+          SHA: ${{ steps.branch.outputs.publish_sha }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/tags/$TAG" -f sha="$SHA" >/dev/null
+          gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" --generate-notes --target "$SHA"

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -86,13 +86,41 @@ jobs:
           git config user.email "smurf-bot[bot]@users.noreply.github.com"
           git add app.py
           if git diff --cached --quiet; then
-            CURRENT_VERSION=$(python3 scripts/read_app_version.py)
-            if [ "$CURRENT_VERSION" != "$VERSION" ]; then
-              echo "APP_VERSION is $CURRENT_VERSION, expected $VERSION"
+            echo "APP_VERSION is already $VERSION; locating merged release PR"
+            MERGED_PR=$(gh pr list --state merged \
+              --search "\"chore(release): bump version to ${VERSION}\" in:title" \
+              --json number,title,author,headRefName,mergeCommit \
+              --limit 50 | jq -r "
+                [.[] | select(
+                  .author.login == \"smurf-bot[bot]\" and
+                  (.headRefName | startswith(\"chore/release-v${VERSION}-\")) and
+                  .mergeCommit.oid != null and
+                  (.mergeCommit.oid | length) > 0
+                )] | .[0] // empty
+              ")
+            if [ -z "$MERGED_PR" ]; then
+              echo "No merged release PR found for version $VERSION"
               exit 1
             fi
-            echo "APP_VERSION is already $VERSION; publishing from current main"
-            echo "publish_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            MERGE_SHA=$(echo "$MERGED_PR" | jq -r '.mergeCommit.oid')
+            VERIFY_FILE="${RUNNER_TEMP}/verify_app_${VERSION}.py"
+            if ! git show "${MERGE_SHA}:app.py" > "$VERIFY_FILE" 2>/dev/null; then
+              echo "Failed to read app.py from merge commit $MERGE_SHA"
+              rm -f "$VERIFY_FILE"
+              exit 1
+            fi
+            if ! COMMIT_VERSION=$(python3 scripts/read_app_version.py "$VERIFY_FILE"); then
+              echo "Failed to read APP_VERSION from merge commit $MERGE_SHA"
+              rm -f "$VERIFY_FILE"
+              exit 1
+            fi
+            rm -f "$VERIFY_FILE"
+            if [ "$COMMIT_VERSION" != "$VERSION" ]; then
+              echo "Merge commit $MERGE_SHA reports APP_VERSION=$COMMIT_VERSION, expected $VERSION"
+              exit 1
+            fi
+            echo "Publishing from merged release PR merge commit $MERGE_SHA"
+            echo "publish_sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "chore(release): bump version to ${VERSION}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -69,29 +69,7 @@ jobs:
         id: release
         run: |
           set -euo pipefail
-          VERSION=$(python3 - <<'PY'
-          import importlib.util
-          import os
-          import sys
-
-          # Drop any inherited APP_VERSION so the module's own default is used.
-          os.environ.pop("APP_VERSION", None)
-          for mod in ("app", "app_stub"):
-              sys.modules.pop(mod, None)
-
-          spec = importlib.util.spec_from_file_location("app", "app.py")
-          if spec is None or spec.loader is None:
-              raise SystemExit("Cannot locate app.py module spec")
-          module = importlib.util.module_from_spec(spec)
-          sys.modules["app"] = module
-          spec.loader.exec_module(module)
-
-          version = getattr(module, "APP_VERSION", None)
-          if not isinstance(version, str) or not version.strip():
-              raise SystemExit("APP_VERSION is missing or empty in app.py")
-          print(version.strip())
-          PY
-          )
+          VERSION=$(python3 scripts/read_app_version.py)
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid APP_VERSION: $VERSION"
             exit 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,21 +31,7 @@ jobs:
           set -euo pipefail
           TAG="${{ github.event.release.tag_name }}"
           TAG="${TAG#v}"
-          VERSION=$(python3 - <<'PY'
-            import importlib.util
-            import os
-            import sys
-            from pathlib import Path
-
-            sys.path.insert(0, str(Path.cwd()))
-            spec = importlib.util.spec_from_file_location("app", "app.py")
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-            version = module.APP_VERSION
-            os.environ["APP_VERSION"] = version
-            print(version)
-          PY
-          )
+          VERSION=$(python3 scripts/read_app_version.py)
           if [ "$VERSION" != "$TAG" ]; then
             echo "ERROR: APP_VERSION ($VERSION) does not match release tag ($TAG)"
             echo "The APP_VERSION constant in app.py must be bumped to $TAG before releasing."

--- a/scripts/read_app_version.py
+++ b/scripts/read_app_version.py
@@ -17,6 +17,8 @@ def read_app_version(path: Path) -> str:
         targets = node.targets if isinstance(node, ast.Assign) else [node.target]
         if not any(isinstance(target, ast.Name) and target.id == "APP_VERSION" for target in targets):
             continue
+        if isinstance(node, ast.AnnAssign) and node.value is None:
+            continue
         values = {
             child.value
             for child in ast.walk(node.value)

--- a/scripts/read_app_version.py
+++ b/scripts/read_app_version.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Read APP_VERSION from app.py without importing application dependencies."""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-.][0-9A-Za-z.-]+)?$")
+
+
+def read_app_version(path: Path) -> str:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(isinstance(target, ast.Name) and target.id == "APP_VERSION" for target in targets):
+            continue
+        values = {
+            child.value
+            for child in ast.walk(node.value)
+            if isinstance(child, ast.Constant)
+            and isinstance(child.value, str)
+            and SEMVER.fullmatch(child.value)
+        }
+        if len(values) != 1:
+            raise ValueError("APP_VERSION must contain one consistent semver default")
+        return values.pop()
+    raise ValueError("APP_VERSION assignment not found")
+
+
+if __name__ == "__main__":
+    source = Path(sys.argv[1] if len(sys.argv) > 1 else "app.py")
+    try:
+        print(read_app_version(source))
+    except (OSError, SyntaxError, ValueError) as exc:
+        raise SystemExit(f"Unable to read APP_VERSION from {source}: {exc}") from exc

--- a/tests/test_read_app_version.py
+++ b/tests/test_read_app_version.py
@@ -26,3 +26,10 @@ def test_rejects_inconsistent_defaults(tmp_path):
     )
     with pytest.raises(ValueError, match="consistent semver"):
         MODULE.read_app_version(app)
+
+
+def test_bare_annotation_falls_through_to_not_found(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("APP_VERSION: str\n")
+    with pytest.raises(ValueError, match="not found"):
+        MODULE.read_app_version(app)

--- a/tests/test_read_app_version.py
+++ b/tests/test_read_app_version.py
@@ -1,0 +1,28 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "read_app_version.py"
+SPEC = importlib.util.spec_from_file_location("read_app_version", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def test_reads_version_without_importing_app_dependencies(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text(
+        'import definitely_missing_dependency\n'
+        'APP_VERSION = (os.environ.get("APP_VERSION") or "1.2.3").strip() or "1.2.3"\n'
+    )
+    assert MODULE.read_app_version(app) == "1.2.3"
+
+
+def test_rejects_inconsistent_defaults(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text(
+        'APP_VERSION = (os.environ.get("APP_VERSION") or "1.2.3").strip() or "1.2.4"\n'
+    )
+    with pytest.raises(ValueError, match="consistent semver"):
+        MODULE.read_app_version(app)


### PR DESCRIPTION
## What

- reads `APP_VERSION` from the Python AST instead of importing the Flask app on a bare Actions runner
- lets Manual Release recover when the requested version is already committed but has no tag/release
- uses the same dependency-free version reader in the image release workflow
- adds regression tests for dependency-free extraction and inconsistent version defaults

## Why

The first `0.1.19` release PR merged, then Publish Release failed because it imported `app.py` without installing Flask. Retrying Manual Release failed earlier with `nothing to commit` because `APP_VERSION` was already `0.1.19`. This makes that state recoverable and prevents application dependencies from breaking release metadata extraction.

## Verification

- `pytest -q` — 208 passed
- workflow YAML parsed successfully
- `python3 scripts/read_app_version.py` — `0.1.19`
- `git diff --check`
