### PR TITLE
docs: issue contract for the autonomous loop (template + AGENTS.md)

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,45 @@
+name: Agent task
+description: Work item for the autonomous coding loop (dispatch → foreman)
+labels: ["type/chore"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Two fields below are load-bearing for the reviewer's automated rails.
+        See AGENTS.md ("Filing issues for the autonomous loop") for why.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why this matters. What breaks, or what is missing, today.
+    validations:
+      required: true
+  - type: input
+    id: ask
+    attributes:
+      label: The ask (one imperative sentence)
+      description: >-
+        The reviewer quotes this verbatim to prove it read the issue. Keep it to a
+        single sentence that states what should change.
+      placeholder: Dedupe incidents on the group signature so a re-fire updates the existing issue.
+    validations:
+      required: true
+  - type: textarea
+    id: files
+    attributes:
+      label: Expected files
+      description: >-
+        Concrete paths the fix should touch, one per line (backticks fine). The
+        reviewer vouches for a diff that touches a named file. Name ONLY paths you
+        are confident about — naming files the diff does not touch reads as scope
+        drift and gets the change rejected. Leave empty if unsure.
+      placeholder: |
+        internal/delivery/github.go
+        internal/triage/group.go
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How a reviewer decides this is done.
+    validations:
+      required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,21 @@ The release PR must pass the protected branch's required lint and test checks be
 **Before working any task, research the problem space first.** This is not optional.
 
 Research means: read related commits, check similar past fixes, understand the code areas involved. Do not guess. Do not start coding before you understand the problem.
+
+## Filing issues for the autonomous loop
+
+Issues here are picked up by an autonomous coding loop (dispatch → foreman), and two
+parts of the body feed deterministic reviewer rails. Agents filing issues in this repo
+must include both.
+
+**1. State the ask in one imperative sentence.** The reviewer quotes it verbatim to
+prove it actually read the issue. If it can only paraphrase, its GO is demoted to NO-GO
+unless the rail below vouches — costing a revision cycle and an escalation review.
+
+**2. Name the concrete file paths the fix is expected to touch** (backticks are fine).
+The scope-overlap rail vouches for a diff that touches a named file, and that vouch is
+what survives a paraphrased ask.
+
+Name only paths you are confident about. An issue that names files the diff does *not*
+touch is read as scope drift and also gets the change rejected — so when unsure, name
+none rather than guessing.


### PR DESCRIPTION
## Summary
Agents file most issues in this repo, and two parts of the body feed deterministic reviewer rails:

- **A one-sentence imperative ask** — the reviewer quotes it verbatim to prove it read the issue. If it can only paraphrase, its GO is demoted to NO-GO.
- **Concrete file paths the fix should touch** — scope-overlap vouches for a diff touching a named file, and that vouch is what survives a paraphrased ask.

An issue with neither loses correct work to a false rejection plus an escalation review — observed today on alert-triage#14.

Adds an `Agent task` issue form and documents the contract in AGENTS.md (appended), including the trap that **naming files the fix does not touch is worse than naming none** (it reads as scope drift and also rejects).

Verified against `scope_overlap.go` / `enforceReviewerIssueAsk` in foreman 0.9.16.